### PR TITLE
feat: move at the end the used compose file

### DIFF
--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -371,7 +371,6 @@ show_usage() {
   echo "  ${0} configure-dns            # Configure DNS only"
   echo "  ${0} up --profile metrics     # Alternative metrics start"
   echo ""
-  echo "Config: ${COMPOSE_FILE}"
   echo ""
   echo "DNS Proxy Environment Variables:"
   echo "  HTTP_PROXY_DNS_TLDS          Top-level domains to proxy (.loc by default)"
@@ -402,6 +401,8 @@ show_usage() {
   echo "Autocomplete:"
   echo "  Quick setup: ${0} install-completion"
   echo "  Manual setup: source <(${0} completion)"
+  echo ""
+  echo "Docker compose file: ${COMPOSE_FILE}"
 }
 
 install_mkcert() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Move compose file display to end of help output

- Improve help text organization and readability

- Add spacing for better visual separation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spark-http-proxy</strong><dd><code>Reorganize help output structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/spark-http-proxy

<li>Moved "Config: ${COMPOSE_FILE}" line from middle to end of help output<br> <li> Added blank line before compose file display for better spacing<br> <li> Reorganized help text structure for improved readability


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/16/files#diff-2277567487100c466f0d7d1f0afcd58e899233b4b967787b9013630de99a5cdc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>