### PR TITLE
Improve mkcert installation support for multiple package managers

### DIFF
--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -412,36 +412,18 @@ install_mkcert() {
     fi
   elif command -v pacman >/dev/null 2>&1; then
     log_info "Installing mkcert with pacman..."
-    log_info "Please run: sudo pacman -S mkcert"
-    log_error "Automatic installation with pacman requires sudo privileges"
-    log_info "After installation, run the command again"
-    return 1
-  elif command -v apt >/dev/null 2>&1; then
-    log_info "Installing mkcert with apt..."
-    log_info "Please run: sudo apt install mkcert"
-    log_error "Automatic installation with apt requires sudo privileges"
-    log_info "After installation, run the command again"
-    return 1
-  elif command -v yum >/dev/null 2>&1; then
-    log_info "Installing mkcert with yum..."
-    log_info "Please run: sudo yum install mkcert"
-    log_error "Automatic installation with yum requires sudo privileges"
-    log_info "After installation, run the command again"
-    return 1
-  elif command -v dnf >/dev/null 2>&1; then
-    log_info "Installing mkcert with dnf..."
-    log_info "Please run: sudo dnf install mkcert"
-    log_error "Automatic installation with dnf requires sudo privileges"
-    log_info "After installation, run the command again"
-    return 1
+    if sudo pacman -S --noconfirm nss mkcert && mkcert -install; then
+      log_success "mkcert installed successfully"
+      return 0
+    else
+      log_error "Failed to install mkcert with pacman"
+      return 1
+    fi
   else
     log_error "mkcert not found and no supported package manager available"
     log_info "Please install mkcert manually:"
-    log_info "  - Arch Linux: sudo pacman -S mkcert"
-    log_info "  - Ubuntu/Debian: sudo apt install mkcert"
-    log_info "  - CentOS/RHEL: sudo yum install mkcert"
-    log_info "  - Fedora: sudo dnf install mkcert"
-    log_info "  - macOS: brew install mkcert"
+    log_info "  - Arch Linux: sudo pacman -S nss mkcert"
+    log_info "  - macOS: brew install mkcert nss"
     return 1
   fi
 }


### PR DESCRIPTION
### **User description**
## Summary
- Add support for Arch Linux (pacman), Ubuntu/Debian (apt), CentOS/RHEL (yum), and Fedora (dnf)
- Replace generic "Homebrew not available" error with specific installation instructions
- Provide clear guidance for manual installation across different Linux distributions

## Problem
Currently, when `mkcert` is not installed on non-macOS systems, users get an unhelpful error message:
```
❌ mkcert not found and Homebrew not available for installation
```

This is particularly problematic on Arch Linux where `mkcert` is available via `pacman`, but users were only told about Homebrew.

## Solution
The `install_mkcert()` function now:
1. Checks for multiple package managers in order of preference
2. Provides specific installation commands for each detected package manager
3. Falls back to comprehensive manual installation instructions

## Test plan
- [x] Tested on Arch Linux with pacman detection
- [x] Verified error messages are helpful and specific
- [x] Confirmed fallback behavior works correctly
- [x] Validated that existing Homebrew functionality is preserved

## Example output on Arch Linux
```
ℹ  Installing mkcert with pacman...
ℹ  Please run: sudo pacman -S mkcert
❌ Automatic installation with pacman requires sudo privileges
ℹ  After installation, run the command again
```


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for multiple Linux package managers (pacman, apt, yum, dnf)

- Replace generic Homebrew error with specific installation instructions

- Provide comprehensive manual installation guidance for all distributions

- Improve user experience with clear package manager detection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spark-http-proxy</strong><dd><code>Enhanced mkcert installation with multi-package manager support</code></dd></summary>
<hr>

bin/spark-http-proxy

<li>Replace single Homebrew check with multi-package manager detection<br> <li> Add support for pacman, apt, yum, and dnf package managers<br> <li> Provide specific installation commands for each detected manager<br> <li> Add comprehensive fallback manual installation instructions


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/64/files#diff-2277567487100c466f0d7d1f0afcd58e899233b4b967787b9013630de99a5cdc">+40/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>