### PR TITLE
docs(agents): add architecture overview and CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 Guidance for agentic coding agents working in this repository.
 
+> `CLAUDE.md` is a symlink to this file. Both Claude Code and other agentic
+> harnesses read the same content — edit `AGENTS.md` only.
+
 ## Repository Overview
 
 Spark HTTP Proxy is a local development reverse proxy built on Traefik. It consists of:
@@ -13,6 +16,70 @@ Spark HTTP Proxy is a local development reverse proxy built on Traefik. It consi
 - **`bin/compose.yml`** — Production compose (GHCR pre-built images)
 - **`compose.yml`** — Development compose (builds from source)
 - **`test/`** — Integration tests only (no unit tests exist)
+
+## Architecture: the big picture
+
+The novel part is not Traefik itself but the three sidecar Go binaries that feed
+and surround it. Understanding their interaction requires reading across `cmd/`,
+`pkg/`, `compose.yml`, and `build/traefik/`.
+
+### The four runtime services (see `compose.yml`)
+
+1. **`traefik`** (container name `http-proxy`) — the actual proxy. Runs with
+   `exposedByDefault: false` (`build/traefik/traefik.yml`), so it ignores every
+   container unless explicitly opted in via `traefik.*` labels or a generated
+   dynamic-config file. Ports 80/443 public, 30000→8080 dashboard.
+2. **`dinghy_layer`** (`cmd/dinghy-layer`) — the compatibility translator.
+   Watches Docker events, reads `VIRTUAL_HOST`/`VIRTUAL_PORT` env vars on
+   containers, and **writes Traefik dynamic YAML config files** into the shared
+   `traefik_dynamic` volume. This is how nginx-proxy/jwilder-style containers
+   work without native Traefik labels.
+3. **`join_networks`** (`cmd/join-networks`) — the connectivity glue. Traefik
+   can only route to containers on networks it has joined. This watches Docker
+   events and **connects the `http-proxy` container to any Docker network that
+   holds a manageable container**. Without it, routes resolve but traffic can't
+   reach the backend. See `docs/network-joining-flow.md`.
+4. **`dns`** (`cmd/dns-server`) — built on `github.com/miekg/dns`. Resolves
+   configured TLDs/domains (default `*.loc`) to `127.0.0.1` so no `/etc/hosts`
+   editing is needed. Optionally forwards non-matching queries upstream.
+   Listens on UDP+TCP 19322.
+
+### The dynamic-config data flow (the key mechanism)
+
+```
+container with VIRTUAL_HOST  ─┐
+                              ├─► dinghy_layer ──writes──► traefik_dynamic volume ──watched by──► traefik ──routes──► container
+container with traefik.* labels ─────────────────────────(read directly by Docker provider)──────►
+                              join_networks ──connects http-proxy to the container's network──►
+```
+
+Two independent paths produce Traefik routes: native `traefik.*` labels (read
+directly by Traefik's Docker provider) and `VIRTUAL_HOST` env vars (translated
+by `dinghy_layer` into files). Both require `join_networks` to have bridged the
+network first.
+
+### Shared Go packages (`pkg/`)
+
+- **`pkg/config`** — env-var loading (`config.go`, all `HTTP_PROXY_DNS_*` vars
+  with defaults) **and** the Traefik dynamic-config YAML structs (`traefik.go`:
+  `TraefikConfig`/`Router`/`Service`/`TLSConfig`). `dinghy_layer` marshals these
+  structs to produce the files Traefik watches.
+- **`pkg/service`** — `docker_event_service.go`: the shared Docker-event-watching
+  loop (`EventHandler` interface, `RunWithSignalHandling`). Both `dinghy_layer`
+  and `join_networks` are `EventHandler` implementations on top of this. Performs
+  an initial full scan, then streams events with signal-based graceful shutdown.
+- **`pkg/logger`**, **`pkg/utils`** — leveled logging (`LOG_LEVEL`) and helpers.
+
+All three binaries build from the **same `build/Dockerfile`** (multi-stage) and
+are selected at runtime by their `command:` in compose.
+
+### Configuration surface
+
+Runtime behaviour is driven by env vars (mostly `HTTP_PROXY_DNS_*` and
+`LOG_LEVEL`), defaulted in `pkg/config/config.go` and wired through
+`compose.yml`. Per-container routing is driven by `VIRTUAL_HOST`/`VIRTUAL_PORT`
+or `traefik.*` labels. When adding an env var, update `pkg/config/config.go`,
+`compose.yml`, `README.md`, and `examples/applications.yml` together.
 
 ## Build Commands
 
@@ -44,6 +111,7 @@ docker compose config           # Validate compose file syntax
 ```
 
 Tests require:
+
 - Docker daemon running
 - Ports 80, 443, 19322 available
 - `dig` and `curl` installed (for DNS and HTTP assertions)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### **User description**
## What

- Add an **Architecture: the big picture** section to `AGENTS.md` covering the four runtime services (`traefik`, `dinghy_layer`, `join_networks`, `dns`), the dynamic-config data flow, the shared `pkg/` roles, and the config surface — the cross-file context that isn't obvious from any single file.
- Make `CLAUDE.md` a **symlink** to `AGENTS.md` so Claude Code and other agentic harnesses read one canonical file. A note at the top of `AGENTS.md` records that `CLAUDE.md` is the symlink and only `AGENTS.md` should be edited.

## Why

`AGENTS.md` already documented commands and style conventions but lacked a high-level architecture map. Onboarding `claude` produced that map; rather than maintain two parallel files, both harnesses now share the same content via a symlink.

## Notes

- No code changes. Docs only.
- Markdown formatted with Prettier.


___

### **PR Type**
Documentation


___

### **Description**
- Add architecture overview section to `AGENTS.md`

- Document four runtime services, data flow, and shared packages

- Create `CLAUDE.md` as symlink to `AGENTS.md`

- Add symlink notice and minor formatting fix in `AGENTS.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AGENTS.md"] -- "symlinked by" --> B["CLAUDE.md"]
  A -- "documents" --> C["Architecture Overview"]
  C -- "covers" --> D["traefik service"]
  C -- "covers" --> E["dinghy_layer service"]
  C -- "covers" --> F["join_networks service"]
  C -- "covers" --> G["dns service"]
  E -- "writes dynamic config" --> D
  F -- "connects networks to" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add architecture overview and symlink notice to AGENTS.md</code></dd></summary>
<hr>

AGENTS.md

<ul><li>Add symlink notice at the top indicating <code>CLAUDE.md</code> points to this file<br> <li> Add "Architecture: the big picture" section covering four runtime <br>services<br> <li> Document dynamic-config data flow with ASCII diagram<br> <li> Document shared <code>pkg/</code> packages and configuration surface<br> <li> Minor formatting fix adding blank line before test requirements list</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/100/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add CLAUDE.md symlink to AGENTS.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

- Create `CLAUDE.md` as a symlink pointing to `AGENTS.md`


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/100/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

