### PR TITLE
docs: link to the spark-http-proxy agent skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@ Guidance for agentic coding agents working in this repository.
 > `CLAUDE.md` is a symlink to this file. Both Claude Code and other agentic
 > harnesses read the same content — edit `AGENTS.md` only.
 
+> **Using this proxy in another project?** A dedicated `spark-http-proxy` agent
+> skill covers exposing containers, certificates, DNS, and troubleshooting:
+> [sparkfabrik/sf-agents-harness → skills/system/spark-http-proxy](https://github.com/sparkfabrik/sf-agents-harness/tree/main/skills/system/spark-http-proxy).
+> This `AGENTS.md` is for working **on** the proxy's own source; the skill is for
+> **using** the proxy from a consumer project.
+
 ## Repository Overview
 
 Spark HTTP Proxy is a local development reverse proxy built on Traefik. It consists of:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 Simply add `VIRTUAL_HOST=myapp.local` to any container or use native Traefik labels, and your applications become accessible with both HTTP and HTTPS automatically. No port management, no `/etc/hosts` editing, no hunting for the right port number. **Only explicitly configured containers are exposed**, keeping your development environment secure by default.
 
+> **Using an AI coding agent?** There is a `spark-http-proxy` agent skill that
+> teaches agents to expose containers, generate certificates, configure DNS, and
+> troubleshoot routing with this proxy:
+> [sparkfabrik/sf-agents-harness → skills/system/spark-http-proxy](https://github.com/sparkfabrik/sf-agents-harness/tree/main/skills/system/spark-http-proxy).
+
 ## Table of Contents
 
 - [Features](#features)
@@ -415,7 +420,7 @@ Traefik automatically generates self-signed certificates for HTTPS routes. For t
 **HTTP Strict Transport Security (HSTS) headers are automatically disabled** for all HTTPS traffic at the entrypoint level to prevent browser caching issues during development. This ensures that:
 
 - Browsers won't remember HTTPS requirements if certificates are changed or revoked
-- Switching between different development setups remains seamless  
+- Switching between different development setups remains seamless
 - Certificate issues don't persist in browser cache and block access
 
 This is implemented using Traefik's `disable-hsts` middleware applied to the HTTPS entrypoint, ensuring **all HTTPS traffic** (both dinghy-layer and native Traefik routes) benefits from this development-friendly configuration. This is essential for development environments where certificates may frequently change, expire, or be regenerated.
@@ -436,6 +441,7 @@ spark-http-proxy generate-mkcert "*.project.loc"
 ```
 
 The `generate-mkcert` command automatically:
+
 - **Installs mkcert** if not already available (using Homebrew on macOS)
 - **Creates the certificate directory** (`~/.local/spark/http-proxy/certs`)
 - **Generates certificates** with safe filenames for wildcard domains


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Add a pointer from this repo to the `spark-http-proxy` **agent skill** in [sparkfabrik/sf-agents-harness](https://github.com/sparkfabrik/sf-agents-harness/tree/main/skills/system/spark-http-proxy), so people (and their AI coding agents) discover it.

- **README.md** — a short callout under the intro for users on an AI coding agent.
- **AGENTS.md** — a note distinguishing working *on* the proxy's own source (this file) from *using* the proxy in a consumer project (the skill).

The skill teaches agents to expose containers (`VIRTUAL_HOST`/`traefik.*`), generate certificates, configure DNS, troubleshoot routing, and uninstall. It is open in sf-agents-harness PR #108 and the link resolves once that merges.

Docs only; no code changes.


___

### **PR Type**
Documentation


___

### **Description**
- Add `spark-http-proxy` agent skill pointer to `README.md` and `AGENTS.md`

- Link to `sparkfabrik/sf-agents-harness` skill for AI coding agents

- Minor formatting fixes in `README.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -- "callout block added" --> B["spark-http-proxy agent skill\n(sf-agents-harness)"]
  C["AGENTS.md"] -- "note added" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add agent skill pointer for consumer project usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Added a callout block at the top distinguishing working on the proxy <br>source vs. using it from a consumer project<br> <li> Links to the <code>spark-http-proxy</code> agent skill in <br><code>sparkfabrik/sf-agents-harness</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/103/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add agent skill link and minor formatting fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added a callout block for AI coding agent users pointing to the <br><code>spark-http-proxy</code> agent skill<br> <li> Minor trailing whitespace fix on one line<br> <li> Added blank line after <code>generate-mkcert</code> command description for <br>formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/103/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

