### PR TITLE
feat(cli): make self-test verify end-to-end routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `upgrade` command to pull latest Docker images and recreate only changed containers, preserving volumes (grafana/prometheus data) ([#96](https://github.com/sparkfabrik/http-proxy/pull/96))
 - Add `self-update` command to update the script and compose files from the git repository, with guards against non-git installs and dirty working trees ([#96](https://github.com/sparkfabrik/http-proxy/pull/96))
 
+### Changed
+
+- `self-test` now verifies end-to-end routing instead of only DNS liveness: it starts a throwaway container with `VIRTUAL_HOST`, asserts DNS resolves the test domain to the configured target IP, and that the proxy serves it over both HTTP and HTTPS (with retries while routes propagate), then cleans up. Exits non-zero with a per-check report on failure ([#104](https://github.com/sparkfabrik/http-proxy/issues/104))
+
 ### Fixed
 
 - Make backend IP and port selection deterministic for `VIRTUAL_HOST` containers attached to multiple networks or exposing multiple ports; previously Go map iteration could route to a different network IP or port across restarts ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -510,48 +510,101 @@ dc_metrics() { docker compose -f "${COMPOSE_FILE}" --profile metrics "$@"; }
 # Check if service is running
 is_running() { dc_cmd ps | grep -q "$1"; }
 
-# Self-test function
+# Poll a URL through the proxy until it returns HTTP 200 or attempts run out.
+# Uses --resolve so both the connection target and the TLS SNI match the test
+# host, exercising the real routing path. Echoes the last status code seen.
+self_test_http_probe() {
+  local scheme="$1" host="$2" port="$3" extra="$4"
+  local code=""
+
+  for _ in $(seq 1 15); do
+    code="$(curl ${extra} -s -o /dev/null -w '%{http_code}' \
+      --resolve "${host}:${port}:127.0.0.1" --max-time 5 \
+      "${scheme}://${host}" 2>/dev/null || true)"
+    if [[ "${code}" == "200" ]]; then
+      echo "200"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "${code}"
+  return 1
+}
+
+# Self-test: end-to-end check that the proxy actually routes a container.
 run_self_test() {
-  local test_domain="test.spark.loc"
-  local container_name="spark-proxy-self-test"
-  local dns_port="${HTTP_PROXY_DNS_PORT:-19322}"
-  local exit_code=0
+  local first_tld test_domain container_name dns_port target_ip
+  local resolved http_code https_code failures=0
 
-  log_info "Running self-test..."
+  first_tld="${HTTP_PROXY_DNS_TLDS:-loc}"
+  first_tld="$(echo "${first_tld%%,*}" | tr -d '[:space:]')"
+  test_domain="spark-http-proxy-selftest.${first_tld}"
+  container_name="spark-proxy-self-test"
+  dns_port="${HTTP_PROXY_DNS_PORT:-19322}"
+  target_ip="${HTTP_PROXY_DNS_TARGET_IP:-127.0.0.1}"
 
-  # Check if DNS service is running
+  log_info "Running self-test (domain: ${test_domain})..."
+
+  # 1. Proxy and DNS services must be up
+  if ! is_running http-proxy; then
+    log_error "HTTP Proxy is not running. Start it first with: ${0} start"
+    return 1
+  fi
   if ! is_running dns; then
     log_error "DNS service is not running. Start the proxy first with: ${0} start"
     return 1
   fi
+  log_success "Proxy and DNS services are running"
 
-  # Start test container
-  log_info "Starting test container..."
-  if ! docker run -d --name "${container_name}" nginx:latest >/dev/null 2>&1; then
+  # Always remove the test container when the function returns
+  trap 'docker rm -f "'"${container_name}"'" >/dev/null 2>&1 || true' RETURN
+
+  # 2. Start a throwaway backend opted into the proxy via VIRTUAL_HOST
+  log_info "Starting test container with VIRTUAL_HOST=${test_domain}..."
+  docker rm -f "${container_name}" >/dev/null 2>&1 || true
+  if ! docker run -d --name "${container_name}" -e "VIRTUAL_HOST=${test_domain}" nginx:latest >/dev/null 2>&1; then
     log_error "Failed to start test container"
     return 1
   fi
 
-  # Test DNS resolution
-  log_info "Testing DNS resolution for ${test_domain}..."
-  if dig @127.0.0.1 -p"${dns_port}" "${test_domain}" +short >/dev/null 2>&1; then
-    log_success "DNS resolution test passed"
+  # 3. DNS must resolve the test domain to the configured target IP
+  log_info "Testing DNS resolution..."
+  resolved="$(dig @127.0.0.1 -p "${dns_port}" "${test_domain}" +short 2>/dev/null | head -n1)"
+  if [[ "${resolved}" == "${target_ip}" ]]; then
+    log_success "DNS resolves ${test_domain} → ${resolved}"
   else
-    log_error "DNS resolution test failed"
-    exit_code=1
+    log_error "DNS resolution failed (got '${resolved:-<empty>}', expected ${target_ip})"
+    failures=$((failures + 1))
   fi
 
-  # Cleanup
-  log_info "Cleaning up test container..."
-  docker rm -f "${container_name}" >/dev/null 2>&1 || true
+  # 4. The proxy must route the test domain over HTTP
+  log_info "Testing HTTP routing (this can take a few seconds to propagate)..."
+  http_code="$(self_test_http_probe http "${test_domain}" 80 "")"
+  if [[ "${http_code}" == "200" ]]; then
+    log_success "HTTP route works (200)"
+  else
+    log_error "HTTP route failed (last status: ${http_code:-none})"
+    failures=$((failures + 1))
+  fi
 
-  if [[ ${exit_code} -eq 0 ]]; then
+  # 5. The proxy must route the test domain over HTTPS (self-signed is fine)
+  log_info "Testing HTTPS routing..."
+  https_code="$(self_test_http_probe https "${test_domain}" 443 "-k")"
+  if [[ "${https_code}" == "200" ]]; then
+    log_success "HTTPS route works (200)"
+  else
+    log_error "HTTPS route failed (last status: ${https_code:-none})"
+    failures=$((failures + 1))
+  fi
+
+  if [[ ${failures} -eq 0 ]]; then
     log_success "Self-test completed successfully"
-  else
-    log_error "Self-test failed"
+    return 0
   fi
 
-  return ${exit_code}
+  log_error "Self-test failed (${failures} check(s) failed)"
+  return 1
 }
 
 # Ensure proxy is running before proceeding


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #104

## Problem

`spark-http-proxy self-test` started a plain `nginx` with **no** `VIRTUAL_HOST`, so the proxy never managed it and routing was never exercised. The only assertion was that `dig` exited 0 (it didn't even check the returned IP). A passing self-test therefore did not mean a container was actually reachable.

## Change

`run_self_test` is now a real end-to-end check:

1. Requires the `http-proxy` and `dns` services to be running.
2. Starts a throwaway container with `VIRTUAL_HOST=<test-domain>` (derived from the first configured TLD, e.g. `spark-http-proxy-selftest.loc`).
3. Asserts DNS resolves that domain to the configured target IP (compares the value).
4. Probes the proxy over **HTTP** and **HTTPS** with `curl --resolve` (so both the connection target and TLS SNI match the host), retrying while routes propagate, and requires `200` on both.
5. Always removes the test container via a `RETURN` trap.

Exits non-zero with a per-check report on failure.

## Verification

Ran against the dev stack (`make dev-up`):

```
ℹ  Running self-test (domain: spark-http-proxy-selftest.loc)...
✅ Proxy and DNS services are running
✅ DNS resolves spark-http-proxy-selftest.loc → 127.0.0.1
✅ HTTP route works (200)
✅ HTTPS route works (200)
✅ Self-test completed successfully
```

Test container cleaned up by the trap (0 leftovers). `bash -n` and shellcheck clean for the changed function.


___

### **PR Type**
Enhancement


___

### **Description**
- `self-test` upgraded from DNS-only check to full end-to-end routing verification

- Adds HTTP and HTTPS proxy routing checks with retry logic via `curl --resolve`

- Validates DNS resolves test domain to configured target IP (value comparison)

- Test container now uses `VIRTUAL_HOST` and is cleaned up via `RETURN` trap


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["self-test starts"] -- "check services" --> B["http-proxy & dns running?"]
  B -- "yes" --> C["start nginx container\nwith VIRTUAL_HOST=test-domain"]
  C -- "DNS check" --> D["dig resolves domain\nto target IP?"]
  D -- "pass" --> E["HTTP probe\ncurl --resolve port 80"]
  E -- "200" --> F["HTTPS probe\ncurl --resolve port 443 -k"]
  F -- "200" --> G["✅ Self-test passed"]
  B -- "no" --> H["❌ Exit non-zero"]
  D -- "fail" --> I["failures++"]
  E -- "fail" --> I
  F -- "fail" --> I
  I --> J["❌ Self-test failed\nper-check report"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spark-http-proxy</strong><dd><code>Upgrade self-test to end-to-end HTTP/HTTPS routing check</code>&nbsp; </dd></summary>
<hr>

bin/spark-http-proxy

<ul><li>Adds <code>self_test_http_probe</code> helper that polls HTTP/HTTPS via <code>curl </code><br><code>--resolve</code> with retries until 200 or timeout<br> <li> <code>run_self_test</code> now checks both <code>http-proxy</code> and <code>dns</code> services are running <br>before proceeding<br> <li> Test container started with <code>VIRTUAL_HOST=<test-domain></code> (derived from first <br>configured TLD)<br> <li> DNS check now compares resolved IP value against <br><code>HTTP_PROXY_DNS_TARGET_IP</code> instead of just checking exit code<br> <li> Adds <code>RETURN</code> trap to always clean up the test container; tracks <br>per-check failures with clear report</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/105/files#diff-2277567487100c466f0d7d1f0afcd58e899233b4b967787b9013630de99a5cdc">+76/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document self-test end-to-end routing change in changelog</code></dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds a "Changed" section entry documenting the <code>self-test</code> end-to-end <br>routing improvement referencing issue #104</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/105/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

