### PR TITLE
feat(cli): add list-certs and remove-cert (multi-domain) commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `list-certs` command to list installed certificates and `remove-cert` command to remove a certificate pair for a domain and restart Traefik ([#107](https://github.com/sparkfabrik/http-proxy/issues/107))
+- Add `list-certs` command to list installed certificates and `remove-cert` command to remove certificate pairs for one or more domains and restart Traefik ([#107](https://github.com/sparkfabrik/http-proxy/issues/107))
 - Unit tests for the pure parsing/config helpers in `dinghy-layer`, `dns-server`, `config`, and `utils` ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - CI `go-checks` job running `gofmt`, `go vet`, and `go test -race` on every non-`main` branch ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - Expose DNS server TCP port 19322 alongside UDP port for Lima virtualization compatibility ([#56](https://github.com/sparkfabrik/http-proxy/issues/56))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `list-certs` command to list installed certificates and `remove-cert` command to remove a certificate pair for a domain and restart Traefik ([#107](https://github.com/sparkfabrik/http-proxy/issues/107))
 - Unit tests for the pure parsing/config helpers in `dinghy-layer`, `dns-server`, `config`, and `utils` ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - CI `go-checks` job running `gofmt`, `go vet`, and `go test -race` on every non-`main` branch ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - Expose DNS server TCP port 19322 alongside UDP port for Lima virtualization compatibility ([#56](https://github.com/sparkfabrik/http-proxy/issues/56))

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Simply add `VIRTUAL_HOST=myapp.local` to any container or use native Traefik lab
   - [Automatic HTTP and HTTPS Routes](#automatic-http-and-https-routes)
   - [Self-Signed Certificates](#self-signed-certificates)
   - [Trusted Local Certificates with mkcert](#trusted-local-certificates-with-mkcert)
+    - [Listing and Removing Certificates](#listing-and-removing-certificates)
     - [Manual Certificate Generation (Alternative)](#manual-certificate-generation-alternative)
     - [Start the proxy](#start-the-proxy)
     - [How Certificate Matching Works](#how-certificate-matching-works)
@@ -446,6 +447,23 @@ The `generate-mkcert` command automatically:
 - **Creates the certificate directory** (`~/.local/spark/http-proxy/certs`)
 - **Generates certificates** with safe filenames for wildcard domains
 - **Restarts Traefik** to load the new certificates immediately
+
+#### Listing and Removing Certificates
+
+List the certificates currently installed in the certificate directory:
+
+```bash
+spark-http-proxy list-certs
+```
+
+Remove a certificate pair for a domain. This deletes both the `.pem` and `-key.pem` files and restarts Traefik so it stops serving the removed certificate:
+
+```bash
+spark-http-proxy remove-cert "nginx.spark.loc"
+spark-http-proxy remove-cert "*.spark.loc"
+```
+
+Pass the same domain you used with `generate-mkcert`, including wildcards. The command asks for confirmation before deleting.
 
 #### Manual Certificate Generation (Alternative)
 

--- a/README.md
+++ b/README.md
@@ -456,14 +456,15 @@ List the certificates currently installed in the certificate directory:
 spark-http-proxy list-certs
 ```
 
-Remove a certificate pair for a domain. This deletes both the `.pem` and `-key.pem` files and restarts Traefik so it stops serving the removed certificate:
+Remove certificate pairs for one or more domains. This deletes both the `.pem` and `-key.pem` files and restarts Traefik so it stops serving the removed certificates:
 
 ```bash
 spark-http-proxy remove-cert "nginx.spark.loc"
 spark-http-proxy remove-cert "*.spark.loc"
+spark-http-proxy remove-cert "nginx.spark.loc" "api.spark.loc" "*.old.loc"
 ```
 
-Pass the same domain you used with `generate-mkcert`, including wildcards. The command asks for confirmation before deleting.
+Pass the same domains you used with `generate-mkcert`, including wildcards. The command lists every match, reports any domain it cannot find, and asks for a single confirmation before deleting.
 
 #### Manual Certificate Generation (Alternative)
 

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -359,7 +359,7 @@ show_usage() {
   echo "  show-config          Show current configuration and file locations"
   echo "  generate-mkcert      Generate SSL certificates for a domain (supports wildcards)"
   echo "  list-certs           List installed certificates"
-  echo "  remove-cert          Remove installed certificates for a domain"
+  echo "  remove-cert          Remove installed certificates for one or more domains"
   echo "  configure-dns        Configure system DNS to automatically resolve proxy domains"
   echo "                       (macOS: /etc/resolver, Linux: systemd-resolved)"
   echo "  completion           Generate shell completion script"
@@ -521,44 +521,59 @@ list_certs() {
   log_info "Remove one with: $(basename "${0}") remove-cert <domain>"
 }
 
-# Remove an installed certificate pair for a domain
+# Remove installed certificate pairs for one or more domains
 remove_cert() {
-  local domain="$1"
-
-  if [ -z "${domain}" ]; then
-    read -rp "Enter domain name to remove: " domain
+  if [ "$#" -eq 0 ]; then
+    local -a prompted=()
+    read -rp "Enter domain name(s) to remove: " -a prompted
+    set -- "${prompted[@]}"
   fi
 
-  if [ -z "${domain}" ]; then
+  if [ "$#" -eq 0 ]; then
     log_error "Domain name required"
     exit 1
   fi
 
-  local safe_filename
-  safe_filename="$(cert_safe_filename "${domain}")"
-  local cert_file="${CERT_DIR}/${safe_filename}.pem"
-  local key_file="${CERT_DIR}/${safe_filename}-key.pem"
+  local -a files=()
+  local -a matched=()
+  local -a missing=()
+  local domain safe_filename cert_file key_file
+  for domain in "$@"; do
+    safe_filename="$(cert_safe_filename "${domain}")"
+    cert_file="${CERT_DIR}/${safe_filename}.pem"
+    key_file="${CERT_DIR}/${safe_filename}-key.pem"
 
-  if [[ ! -f "${cert_file}" && ! -f "${key_file}" ]]; then
+    if [[ ! -f "${cert_file}" && ! -f "${key_file}" ]]; then
+      missing+=("${domain}")
+      continue
+    fi
+
+    log_warning "Will remove certificate for: ${domain}"
+    [[ -f "${cert_file}" ]] && { log_info "  Certificate: ${cert_file}"; files+=("${cert_file}"); }
+    [[ -f "${key_file}" ]] && { log_info "  Private key: ${key_file}"; files+=("${key_file}"); }
+    matched+=("${domain}")
+  done
+
+  for domain in "${missing[@]}"; do
     log_error "No certificate found for domain: ${domain}"
+  done
+
+  if [[ "${#matched[@]}" -eq 0 ]]; then
     log_info "List installed certificates with: $(basename "${0}") list-certs"
     exit 1
   fi
 
-  log_warning "This will remove the certificate for: ${domain}"
-  [[ -f "${cert_file}" ]] && log_info "  Certificate: ${cert_file}"
-  [[ -f "${key_file}" ]] && log_info "  Private key: ${key_file}"
-  read -p "Are you sure? (y/N): " -n 1 -r
+  read -p "Remove ${#matched[@]} certificate(s)? (y/N): " -n 1 -r
   echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     log_info "Removal cancelled"
     return 0
   fi
 
-  rm -f "${cert_file}" "${key_file}"
-  log_success "Certificate removed for: ${domain}"
+  rm -f "${files[@]}"
+  log_success "Removed ${#matched[@]} certificate(s): ${matched[*]}"
 
-  # Restart traefik so it stops serving the removed certificate.
+  # Restart traefik so it stops serving the removed certificates.
   if is_running http-proxy; then
     log_info "Restarting Traefik to apply the change..."
     docker compose -f "${COMPOSE_FILE}" restart traefik
@@ -990,7 +1005,7 @@ completion) generate_completion ;;
 install-completion) install_completion ;;
 generate-mkcert) generate_mkcert "${2}" ;;
 list-certs) list_certs ;;
-remove-cert) remove_cert "${2}" ;;
+remove-cert) remove_cert "${@:2}" ;;
 upgrade)
   ensure_running
   log_info "Upgrading HTTP Proxy images..."

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -201,7 +201,7 @@ _${script_name//-/_}_completion() {
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
     # Available commands
-    commands="version help self-test start status restart start-with-metrics stop-metrics clean destroy logs dashboard grafana prometheus configure-dns completion install-completion generate-mkcert upgrade self-update up down pull build ps top exec show-config"
+    commands="version help self-test start status restart start-with-metrics stop-metrics clean destroy logs dashboard grafana prometheus configure-dns completion install-completion generate-mkcert list-certs remove-cert upgrade self-update up down pull build ps top exec show-config"
 
     # Available services for logs command
     services="traefik dinghy_layer join_networks dns prometheus grafana"
@@ -211,7 +211,7 @@ _${script_name//-/_}_completion() {
             COMPREPLY=( \$(compgen -W "\${services}" -- \${cur}) )
             return 0
             ;;
-        generate-mkcert)
+        generate-mkcert|remove-cert)
             # No completion for domain names
             return 0
             ;;
@@ -323,7 +323,7 @@ open_url() {
 
 # Ensure prerequisites are met
 # Ignore if the first argument is "help" or "version" or "completion".
-if [[ "$1" != "help" && "$1" != "version" && "$1" != "completion" && "$1" != "install-completion" && "$1" != "self-update" ]]; then
+if [[ "$1" != "help" && "$1" != "version" && "$1" != "completion" && "$1" != "install-completion" && "$1" != "self-update" && "$1" != "list-certs" ]]; then
   if ! check_prerequisites; then
     exit 1
   fi
@@ -358,6 +358,8 @@ show_usage() {
   echo "Configuration & Setup:"
   echo "  show-config          Show current configuration and file locations"
   echo "  generate-mkcert      Generate SSL certificates for a domain (supports wildcards)"
+  echo "  list-certs           List installed certificates"
+  echo "  remove-cert          Remove installed certificates for a domain"
   echo "  configure-dns        Configure system DNS to automatically resolve proxy domains"
   echo "                       (macOS: /etc/resolver, Linux: systemd-resolved)"
   echo "  completion           Generate shell completion script"
@@ -449,11 +451,8 @@ generate_mkcert() {
   fi
 
   # Create a safe filename for wildcard domains
-  local safe_filename="${domain}"
-  # Replace * with _wildcard_ for filename safety
-  safe_filename="${safe_filename//\*/_wildcard_}"
-  # Replace other problematic characters
-  safe_filename="${safe_filename//\//_}"
+  local safe_filename
+  safe_filename="$(cert_safe_filename "${domain}")"
 
   log_info "Generating certificates for: ${domain}"
   log_info "Certificate files will be named: ${safe_filename}.pem and ${safe_filename}-key.pem"
@@ -469,6 +468,101 @@ generate_mkcert() {
   # Restart traefik to apply new certificates.
   log_info "Restarting Traefik to apply new certificates..."
   docker compose -f "${COMPOSE_FILE}" restart traefik
+}
+
+# Derive the safe filename used to store a domain's certificate files
+cert_safe_filename() {
+  local domain="$1"
+  local safe_filename="${domain}"
+  # Replace * with _wildcard_ for filename safety
+  safe_filename="${safe_filename//\*/_wildcard_}"
+  # Replace other problematic characters
+  safe_filename="${safe_filename//\//_}"
+  echo "${safe_filename}"
+}
+
+# List installed certificates in the cert directory
+list_certs() {
+  log_info "Certificate directory: ${CERT_DIR}"
+
+  local found=0
+  local cert_file
+  for cert_file in "${CERT_DIR}"/*.pem; do
+    # Guard against the literal glob when no files match
+    [[ -e "${cert_file}" ]] || break
+    # Skip key files; they are listed alongside their certificate
+    [[ "${cert_file}" == *-key.pem ]] && continue
+
+    local safe_filename
+    safe_filename="$(basename "${cert_file}" .pem)"
+    # Reverse the safe-filename mapping for display
+    local domain="${safe_filename//_wildcard_/\*}"
+
+    echo ""
+    log_success "${domain}"
+    log_info "  Certificate: ${cert_file}"
+    local key_file="${CERT_DIR}/${safe_filename}-key.pem"
+    if [[ -f "${key_file}" ]]; then
+      log_info "  Private key: ${key_file}"
+    else
+      log_warning "  Private key missing: ${key_file}"
+    fi
+    found=$((found + 1))
+  done
+
+  if [[ "${found}" -eq 0 ]]; then
+    echo ""
+    log_warning "No certificates found. Generate one with: $(basename "${0}") generate-mkcert <domain>"
+    return 0
+  fi
+
+  echo ""
+  log_info "${found} certificate(s) installed"
+  log_info "Remove one with: $(basename "${0}") remove-cert <domain>"
+}
+
+# Remove an installed certificate pair for a domain
+remove_cert() {
+  local domain="$1"
+
+  if [ -z "${domain}" ]; then
+    read -rp "Enter domain name to remove: " domain
+  fi
+
+  if [ -z "${domain}" ]; then
+    log_error "Domain name required"
+    exit 1
+  fi
+
+  local safe_filename
+  safe_filename="$(cert_safe_filename "${domain}")"
+  local cert_file="${CERT_DIR}/${safe_filename}.pem"
+  local key_file="${CERT_DIR}/${safe_filename}-key.pem"
+
+  if [[ ! -f "${cert_file}" && ! -f "${key_file}" ]]; then
+    log_error "No certificate found for domain: ${domain}"
+    log_info "List installed certificates with: $(basename "${0}") list-certs"
+    exit 1
+  fi
+
+  log_warning "This will remove the certificate for: ${domain}"
+  [[ -f "${cert_file}" ]] && log_info "  Certificate: ${cert_file}"
+  [[ -f "${key_file}" ]] && log_info "  Private key: ${key_file}"
+  read -p "Are you sure? (y/N): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    log_info "Removal cancelled"
+    return 0
+  fi
+
+  rm -f "${cert_file}" "${key_file}"
+  log_success "Certificate removed for: ${domain}"
+
+  # Restart traefik so it stops serving the removed certificate.
+  if is_running http-proxy; then
+    log_info "Restarting Traefik to apply the change..."
+    docker compose -f "${COMPOSE_FILE}" restart traefik
+  fi
 }
 
 open_dashboard() {
@@ -895,6 +989,8 @@ prometheus) open_prometheus ;;
 completion) generate_completion ;;
 install-completion) install_completion ;;
 generate-mkcert) generate_mkcert "${2}" ;;
+list-certs) list_certs ;;
+remove-cert) remove_cert "${2}" ;;
 upgrade)
   ensure_running
   log_info "Upgrading HTTP Proxy images..."


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Adds two certificate-management commands to `bin/spark-http-proxy`, filling the gap left by `generate-mkcert` which could create certificates but offered no way to inspect or clean them up.

- `list-certs` lists the certificate pairs installed in `~/.local/spark/http-proxy/certs`, showing each domain and its backing files, and prints a count plus a removal hint at the end. Wildcard filenames are mapped back to their domain form (`_wildcard_.spark.loc` displays as `*.spark.loc`). This command needs no Docker and is added to the prerequisite skip list.
- `remove-cert <domain>...` deletes the certificate pair (`.pem` and `-key.pem`) for one or more domains after a single confirmation, then restarts Traefik if it is running so it stops serving the removed certificates. It accepts the same domain form as `generate-mkcert`, including wildcards.

## Behavior of `remove-cert`

- Accepts any number of domains in one invocation.
- Lists every matching certificate and reports any domain it cannot find.
- Missing domains do not block valid ones; the command proceeds with what it found.
- Asks for a single `y/N` confirmation for the whole batch, deletes the files, then restarts Traefik once.
- Exits non-zero only when none of the requested domains match an installed certificate.

## Implementation notes

- The safe-filename derivation (`*` to `_wildcard_`, `/` to `_`) is extracted into a shared `cert_safe_filename` helper, and `generate_mkcert` now calls it so generation and removal stay in sync.
- Both commands are wired in all four required places: the function definition, the `case` dispatch, `show_usage`, and `generate_completion`. Command-name completion offers `list-certs` and `remove-cert`, and `remove-cert` shares `generate-mkcert`'s no-completion-for-domains behavior.
- `list-certs` is added to the prerequisite skip list because it needs no Docker.
- `CHANGELOG.md` and `README.md` are updated, including a new "Listing and Removing Certificates" section and a table-of-contents entry.

## Testing

- `bash -n bin/spark-http-proxy` passes.
- `list-certs` lists all installed certificates, correctly reverses wildcard filenames, and prints the summary footer.
- `remove-cert` with a mix of existing and missing domains lists the matches, reports the missing ones, and cancels cleanly on `n` without deleting anything; a request with no matches exits non-zero.
- Command-name completion returns `list-certs` for `list` and `remove-cert` for `remove`, and suppresses completion for the `remove-cert` domain argument, verified under bash.

Closes: sparkfabrik/http-proxy#107
