### PR TITLE
fix(dinghy-layer): prune orphaned config files on initial scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reconcile the generated `dinghy-layer` config files against running containers during the initial scan, removing orphaned files whose container no longer exists; a recreated container previously kept a stale backend IP that returned `502` until a full teardown ([#109](https://github.com/sparkfabrik/http-proxy/issues/109))
 - Make backend IP and port selection deterministic for `VIRTUAL_HOST` containers attached to multiple networks or exposing multiple ports; previously Go map iteration could route to a different network IP or port across restarts ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - Lower generated DNS A-record TTL from 3600s to 60s so a changed `HTTP_PROXY_DNS_TARGET_IP` propagates quickly instead of being cached by the OS stub resolver ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - Guard against a nil-pointer panic in `join-networks` when a container reports no network settings ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))

--- a/cmd/dinghy-layer/main.go
+++ b/cmd/dinghy-layer/main.go
@@ -114,19 +114,45 @@ func (cl *CompatibilityLayer) HandleInitialScan(ctx context.Context) error {
 
 	cl.logger.Info("Scanning existing containers", "count", len(containers))
 
+	// keep holds the config file names of the containers processed in this scan.
+	// After the scan it drives reconciliation: any dinghy-layer config file not
+	// in this set belongs to a container that no longer exists and is removed.
+	keep := make(map[string]struct{})
+	scanErrors := 0
+
 	for _, cont := range containers {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if err := cl.processContainer(ctx, cont.ID); err != nil {
+			name, err := cl.processContainer(ctx, cont.ID)
+			if err != nil {
+				scanErrors++
 				cl.logger.Error("Failed to process container",
 					"error", err,
 					"container_id", utils.FormatDockerID(cont.ID),
 					"container_name", cont.Names)
 				// Continue processing other containers instead of failing fast
+				continue
+			}
+			if name != "" {
+				keep[name] = struct{}{}
 			}
 		}
+	}
+
+	// Skip reconciliation when a container could not be inspected. A transient
+	// inspect failure would leave that container out of keep, and pruning then
+	// would delete the config of a container that is still running. Reconcile
+	// only when the scan saw every container cleanly.
+	if scanErrors > 0 {
+		cl.logger.Warn("Skipping orphaned-config reconciliation after scan errors",
+			"errors", scanErrors)
+		return nil
+	}
+
+	if err := cl.reconcileConfigs(keep); err != nil {
+		cl.logger.Error("Failed to reconcile Traefik configs", "error", err)
 	}
 
 	return nil
@@ -136,7 +162,8 @@ func (cl *CompatibilityLayer) HandleInitialScan(ctx context.Context) error {
 func (cl *CompatibilityLayer) HandleEvent(ctx context.Context, event events.Message) error {
 	switch event.Action {
 	case "start":
-		return cl.processContainer(ctx, event.Actor.ID)
+		_, err := cl.processContainer(ctx, event.Actor.ID)
+		return err
 	case "die":
 		return cl.removeTraefikConfig(event.Actor.ID)
 	default:
@@ -172,10 +199,15 @@ func main() {
 	}
 }
 
-func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID string) error {
+// processContainer inspects a container and writes or refreshes its Traefik
+// config file. It returns the base name of the config file it wrote, or an
+// empty string when the container is skipped (not running, no VIRTUAL_HOST, or
+// already managed by native Traefik labels). The returned name lets the initial
+// scan know which files must survive reconciliation.
+func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID string) (string, error) {
 	inspect, err := utils.RetryContainerInspect(ctx, cl.dockerClient, containerID)
 	if err != nil {
-		return fmt.Errorf("failed to inspect container %s: %w", containerID, err)
+		return "", fmt.Errorf("failed to inspect container %s: %w", containerID, err)
 	}
 
 	// Extract container information
@@ -186,7 +218,7 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		cl.logger.Debug("Skipping non-running container",
 			"container_id", utils.FormatDockerID(containerID),
 			"container_name", containerInfo.Name)
-		return nil
+		return "", nil
 	}
 
 	// Skip if no VIRTUAL_HOST found
@@ -194,7 +226,7 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		cl.logger.Debug("Skipping container without VIRTUAL_HOST",
 			"container_id", utils.FormatDockerID(containerID),
 			"container_name", containerInfo.Name)
-		return nil
+		return "", nil
 	}
 
 	// Skip if traefik labels are already set; native labels take precedence and
@@ -203,7 +235,7 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		cl.logger.Debug("Skipping container with existing Traefik label",
 			"container_id", utils.FormatDockerID(containerID),
 			"container_name", containerInfo.Name)
-		return nil
+		return "", nil
 	}
 
 	cl.logger.Info("Found container with VIRTUAL_HOST",
@@ -221,7 +253,11 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		"services", len(traefikConfig.HTTP.Services))
 
 	// Write Traefik configuration to file
-	return cl.writeTraefikConfig(containerID, traefikConfig)
+	if err := cl.writeTraefikConfig(containerID, traefikConfig); err != nil {
+		return "", err
+	}
+
+	return cl.configFileName(containerID), nil
 }
 
 func (cl *CompatibilityLayer) generateTraefikConfig(inspect types.ContainerJSON, containerInfo ContainerInfo) *config.TraefikConfig {
@@ -404,6 +440,54 @@ func (cl *CompatibilityLayer) removeTraefikConfig(containerID string) error {
 	return nil
 }
 
+// reconcileConfigs removes the config files of containers that no longer exist.
+// keep holds the base names of the config files that must survive, one per
+// container processed in the current scan. Only files this service owns (those
+// matching dinghyConfigFilePattern) are eligible for removal, so certificate,
+// middleware, and auto-TLS files sharing the dynamic directory are left alone.
+//
+// This is what reconciles a recreated container's IP. When the container's die
+// event was missed, its old config file survives with a stale backend endpoint;
+// the next scan removes it because no current container maps to that file.
+func (cl *CompatibilityLayer) reconcileConfigs(keep map[string]struct{}) error {
+	entries, err := os.ReadDir(cl.config.TraefikDynamicDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read Traefik dynamic directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !isDinghyConfigFile(name) {
+			continue
+		}
+		if _, ok := keep[name]; ok {
+			continue
+		}
+
+		if cl.config.DryRun {
+			cl.logger.Info("DRY RUN: Would remove orphaned Traefik config", "config_file", name)
+			continue
+		}
+
+		path := filepath.Join(cl.config.TraefikDynamicDir, name)
+		if err := os.Remove(path); err != nil {
+			cl.logger.Error("Failed to remove orphaned Traefik config", "error", err, "config_file", name)
+			continue
+		}
+
+		cl.logger.Info("Removed orphaned Traefik configuration", "config_file", name)
+	}
+
+	return nil
+}
+
 type virtualHost struct {
 	hostname string
 	port     string
@@ -548,4 +632,17 @@ func tcpPortNumber(port string) int {
 // configFileName returns the config file name for a container
 func (cl *CompatibilityLayer) configFileName(containerID string) string {
 	return fmt.Sprintf("%s.yaml", utils.FormatDockerID(containerID))
+}
+
+// dinghyConfigFilePattern matches the config file names this service generates:
+// the 12-character short container ID from utils.FormatDockerID followed by
+// ".yaml". It deliberately excludes the other files that share the Traefik
+// dynamic directory, such as the entrypoint-generated auto-tls.yml and the
+// middlewares copied in at image build time.
+var dinghyConfigFilePattern = regexp.MustCompile(`^[0-9a-f]{12}\.yaml$`)
+
+// isDinghyConfigFile reports whether name is a config file generated by this
+// service, and therefore safe for reconciliation to remove.
+func isDinghyConfigFile(name string) bool {
+	return dinghyConfigFilePattern.MatchString(name)
 }

--- a/cmd/dinghy-layer/main_test.go
+++ b/cmd/dinghy-layer/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -305,6 +307,100 @@ func TestGenerateTraefikConfigWildcardUsesHostRegexp(t *testing.T) {
 	}
 	if router.Rule != "HostRegexp(`^.*\\.wild\\.loc$`)" {
 		t.Errorf("wildcard rule = %q, want HostRegexp(`^.*\\.wild\\.loc$`)", router.Rule)
+	}
+}
+
+func TestIsDinghyConfigFile(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"0123456789ab.yaml", true},
+		{"abcdef012345.yaml", true},
+		{"auto-tls.yml", false},
+		{"hsts.yaml", false},
+		{"0123456789ab.yml", false},   // wrong extension
+		{"0123456789a.yaml", false},   // 11 chars, too short
+		{"0123456789abc.yaml", false}, // 13 chars, too long
+		{"0123456789AB.yaml", false},  // uppercase not produced by FormatDockerID
+		{"0123456789ag.yaml", false},  // non-hex character
+		{"0123456789ab.yaml.tmp", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isDinghyConfigFile(tt.in); got != tt.want {
+			t.Errorf("isDinghyConfigFile(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestReconcileConfigsRemovesOnlyOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	// A recreated container leaves both its current file (kept) and a stale one
+	// (orphaned). The shared directory also holds files this service must never
+	// touch: the entrypoint's auto-tls.yml, a certificate config, and the
+	// middlewares subdirectory.
+	orphan := "aaaaaaaaaaaa.yaml"
+	current := "bbbbbbbbbbbb.yaml"
+	files := []string{orphan, current, "auto-tls.yml", "custom-cert.yaml"}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("http: {}\n"), 0o644); err != nil {
+			t.Fatalf("failed to seed %s: %v", name, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "middlewares"), 0o755); err != nil {
+		t.Fatalf("failed to seed middlewares dir: %v", err)
+	}
+
+	cl := &CompatibilityLayer{
+		logger: logger.New("test"),
+		config: &CompatibilityConfig{TraefikDynamicDir: dir},
+	}
+
+	keep := map[string]struct{}{current: {}}
+	if err := cl.reconcileConfigs(keep); err != nil {
+		t.Fatalf("reconcileConfigs returned error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, orphan)); !os.IsNotExist(err) {
+		t.Errorf("orphaned config %s should have been removed", orphan)
+	}
+	survivors := []string{current, "auto-tls.yml", "custom-cert.yaml", "middlewares"}
+	for _, name := range survivors {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("%s should have survived reconciliation: %v", name, err)
+		}
+	}
+}
+
+func TestReconcileConfigsDryRunKeepsFiles(t *testing.T) {
+	dir := t.TempDir()
+	orphan := "cccccccccccc.yaml"
+	if err := os.WriteFile(filepath.Join(dir, orphan), []byte("http: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %s: %v", orphan, err)
+	}
+
+	cl := &CompatibilityLayer{
+		logger: logger.New("test"),
+		config: &CompatibilityConfig{TraefikDynamicDir: dir, DryRun: true},
+	}
+
+	if err := cl.reconcileConfigs(map[string]struct{}{}); err != nil {
+		t.Fatalf("reconcileConfigs returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, orphan)); err != nil {
+		t.Errorf("dry run must not remove %s: %v", orphan, err)
+	}
+}
+
+func TestReconcileConfigsMissingDir(t *testing.T) {
+	cl := &CompatibilityLayer{
+		logger: logger.New("test"),
+		config: &CompatibilityConfig{TraefikDynamicDir: filepath.Join(t.TempDir(), "does-not-exist")},
+	}
+	if err := cl.reconcileConfigs(map[string]struct{}{}); err != nil {
+		t.Errorf("reconcileConfigs on missing dir should be a no-op, got %v", err)
 	}
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -40,6 +40,7 @@ TRAEFIK_CONTAINER="test-traefik-app"
 VIRTUAL_HOST_CONTAINER="test-virtual-host-app"
 VIRTUAL_HOST_PORT_CONTAINER="test-virtual-host-port-app"
 MULTI_VIRTUAL_HOST_CONTAINER="test-multi-virtual-host-app"
+ORPHAN_CONTAINER="test-orphan-reconcile-app"
 
 # Hostname configurations for DNS testing
 TRAEFIK_HOSTNAME="app1.${TEST_DOMAIN}"
@@ -47,6 +48,7 @@ VIRTUAL_HOST_HOSTNAME="app2.${TEST_DOMAIN}"
 VIRTUAL_HOST_PORT_HOSTNAME="app3.${TEST_DOMAIN}"
 MULTI_VIRTUAL_HOST_HOSTNAME1="app4.${TEST_DOMAIN}"
 MULTI_VIRTUAL_HOST_HOSTNAME2="app5.${TEST_DOMAIN}"
+ORPHAN_HOSTNAME="app6.${TEST_DOMAIN}"
 
 # Logging function
 log() {
@@ -149,6 +151,71 @@ test_hsts_headers() {
 
     error "HTTPS access to ${hostname} failed after ${max_attempts} attempts"
     return 1
+}
+
+# Test that a recreated container's orphaned config is pruned on the next
+# initial scan (issue #109). Stopping dinghy_layer makes it miss the die event,
+# so the old container's config file survives as an orphan with a stale backend
+# until reconciliation removes it.
+test_orphan_config_reconciliation() {
+    docker run -d --name "$ORPHAN_CONTAINER" \
+        --env "VIRTUAL_HOST=${ORPHAN_HOSTNAME}" nginx:alpine
+    wait_for_container "$ORPHAN_CONTAINER" || return 1
+    test_http_access "$ORPHAN_HOSTNAME" || return 1
+
+    local old_id
+    old_id=$(docker inspect --format '{{.Id}}' "$ORPHAN_CONTAINER" | cut -c1-12)
+    if ! docker exec http-proxy test -f "/traefik/dynamic/${old_id}.yaml"; then
+        error "Expected config file ${old_id}.yaml was not generated"
+        return 1
+    fi
+
+    local had_auto_tls=0
+    docker exec http-proxy test -f /traefik/dynamic/auto-tls.yml && had_auto_tls=1
+
+    log "Stopping dinghy_layer to simulate a missed die event..."
+    docker compose stop dinghy_layer
+
+    docker rm -f "$ORPHAN_CONTAINER"
+    docker run -d --name "$ORPHAN_CONTAINER" \
+        --env "VIRTUAL_HOST=${ORPHAN_HOSTNAME}" nginx:alpine
+    wait_for_container "$ORPHAN_CONTAINER" || return 1
+
+    local new_id
+    new_id=$(docker inspect --format '{{.Id}}' "$ORPHAN_CONTAINER" | cut -c1-12)
+
+    log "Restarting dinghy_layer to trigger the initial scan..."
+    docker compose start dinghy_layer
+
+    # Wait for the initial scan to reconcile the orphaned config
+    local attempt=1
+    while [ $attempt -le 10 ]; do
+        if ! docker exec http-proxy test -f "/traefik/dynamic/${old_id}.yaml"; then
+            break
+        fi
+        wait_with_message "$SLEEP_CONTAINER_CHECK" "for the initial scan to reconcile configs"
+        attempt=$((attempt + 1))
+    done
+
+    if docker exec http-proxy test -f "/traefik/dynamic/${old_id}.yaml"; then
+        error "Orphaned config ${old_id}.yaml was not removed"
+        return 1
+    fi
+    success "Orphaned config ${old_id}.yaml was removed"
+
+    if ! docker exec http-proxy test -f "/traefik/dynamic/${new_id}.yaml"; then
+        error "Config ${new_id}.yaml for the recreated container is missing"
+        return 1
+    fi
+    if [ "$had_auto_tls" -eq 1 ] && ! docker exec http-proxy test -f /traefik/dynamic/auto-tls.yml; then
+        error "auto-tls.yml was removed by reconciliation"
+        return 1
+    fi
+    test_http_access "$ORPHAN_HOSTNAME" || return 1
+    success "Recreated container config and shared files survived reconciliation"
+
+    docker rm -f "$ORPHAN_CONTAINER" >/dev/null 2>&1 || true
+    return 0
 }
 
 # Test DNS functionality
@@ -561,7 +628,7 @@ test_with_dns_config() {
 
 # Cleanup test containers
 cleanup() {
-    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" 2>/dev/null || true
+    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" "$ORPHAN_CONTAINER" 2>/dev/null || true
 }
 
 # Full stack cleanup and rebuild
@@ -645,6 +712,13 @@ main() {
     test_hsts_headers "app5.${TEST_DOMAIN}" && hsts_passed=$((hsts_passed + 1))
     [ "$hsts_passed" -eq 5 ] && passed=$((passed + 1))
 
+    # Orphaned config reconciliation test (issue #109)
+    log "Testing orphaned config reconciliation..."
+    total=$((total + 1))
+    local orphan_passed=0
+    test_orphan_config_reconciliation && orphan_passed=1
+    [ "$orphan_passed" -eq 1 ] && passed=$((passed + 1))
+
     # DNS Tests (if dig available)
     if command -v dig >/dev/null 2>&1; then
         log "Testing DNS functionality..."
@@ -669,6 +743,7 @@ main() {
     log "============="
     log "HTTP Tests: ${http_passed}/5 passed"
     log "HSTS Tests: ${hsts_passed}/5 passed"
+    log "Orphan Reconciliation Tests: ${orphan_passed}/1 passed"
     log "Test Suites: ${passed}/${total} passed"
 
     cleanup


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @abarnto._

## What this fixes

A container with `VIRTUAL_HOST` that is recreated with a new IP could keep a stale backend endpoint in its Traefik route. The URL then returned `502` while the backend was healthy, and no proxy or container restart reconciled it. Only a full teardown that removed the `traefik_dynamic` volume cleared it.

Closes #109.

## Root cause

`dinghy-layer` writes one Traefik dynamic config file per container, named by the container ID, and removes that file only on the container `die` event. The Traefik service inside each file is keyed by the container name, not the ID.

`HandleInitialScan` writes a file for each running managed container but never prunes. When a `die` event is missed (for example `dinghy-layer` was not running at the moment the old container was removed), the old `<id>.yaml` survives as an orphan. Two files then define the same Traefik service name, the file provider merges them, and the stale endpoint can win. A restart does not help, because the scan only adds files, so only wiping the volume cleared the orphan.

## The change

`HandleInitialScan` now reconciles the dynamic directory against the running containers. It collects the config file name of every container it processes into a `keep` set, then calls a new `reconcileConfigs` that removes any config file this service owns whose container is no longer present.

The prune is deliberately narrow.

- **Only this service's own files are eligible.** They match `^[0-9a-f]{12}\.yaml$`, the 12-character short container ID plus `.yaml`. Certificate configs, the entrypoint-generated `auto-tls.yml`, and the `middlewares/` subdirectory sharing the volume are left untouched.
- **Reconciliation is skipped when any container fails to inspect during the scan.** A transient inspect failure would leave a still-running container out of `keep`, so pruning in that state could delete a live route. The scan reconciles only when it saw every container cleanly; otherwise the next restart heals the orphan.

`processContainer` now returns the base name of the file it wrote (empty when it skips the container), which is what feeds the `keep` set.

This makes `spark-http-proxy restart` recover a stale state that previously needed a full teardown.

## Verification

- `go test -race ./...` passes. New unit tests cover the file-name matcher (`TestIsDinghyConfigFile`) and the reconcile behavior: an orphan is removed while the current file and the protected `auto-tls.yml`, certificate, and `middlewares/` entries survive (`TestReconcileConfigsRemovesOnlyOrphans`), dry-run keeps files, and a missing directory is a no-op.
- `gofmt -l ./cmd ./pkg` and `go vet ./...` are clean.
- `make test` (Docker integration suite) passes locally.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Prune orphaned `dinghy-layer` configs after scans

- Preserve shared Traefik files and directories

- Skip pruning when container inspection fails

- Add reconciliation and filename matcher coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Scan["Initial container scan"]
  Keep["Current generated config files"]
  Reconcile["Reconcile dynamic config directory"]
  Prune["Remove orphaned container configs"]
  Scan -- "collects" --> Keep
  Keep -- "drives" --> Reconcile
  Reconcile -- "prunes stale files" --> Prune
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Reconcile stale generated Traefik container configurations</code></dd></summary>
<hr>

cmd/dinghy-layer/main.go

<ul><li>Track generated config filenames for successfully scanned containers.<br> <li> Reconcile top-level generated config files after error-free scans.<br> <li> Remove only short hexadecimal container-ID <code>.yaml</code> orphan files.<br> <li> Preserve dry-run behavior and skip pruning after inspection failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/110/files#diff-6f7909d862402f3a0dd82ff94d73a0a7d2ebbbea860b2fd0e2f399338450dc06">+105/-8</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main_test.go</strong><dd><code>Test orphaned configuration reconciliation safeguards</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/dinghy-layer/main_test.go

<ul><li>Test generated config filename matching boundaries.<br> <li> Verify orphan removal preserves shared files and directories.<br> <li> Cover dry-run and missing dynamic directory behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/110/files#diff-fb3677cf7fb77ec04aa325af43fabb6aa0a6a0dca85b19c1982e4bcc8692c70a">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document stale backend configuration fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document the stale backend IP reconciliation fix.<br> <li> Reference issue <code>#109</code> and affected <code>502</code> behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/110/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra