### PR TITLE
fix(dinghy-layer): ignore one-off compose run containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ignore one-off containers created by `docker compose run` (labelled `com.docker.compose.oneoff=True`) in `dinghy-layer` and `join-networks`; they inherit `VIRTUAL_HOST` from the service definition and could claim the service domain with a backend port nothing listens on, returning `502` ([#111](https://github.com/sparkfabrik/http-proxy/issues/111))
 - Reconcile the generated `dinghy-layer` config files against running containers during the initial scan, removing orphaned files whose container no longer exists; a recreated container previously kept a stale backend IP that returned `502` until a full teardown ([#109](https://github.com/sparkfabrik/http-proxy/issues/109))
 - Make backend IP and port selection deterministic for `VIRTUAL_HOST` containers attached to multiple networks or exposing multiple ports; previously Go map iteration could route to a different network IP or port across restarts ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - Lower generated DNS A-record TTL from 3600s to 60s so a changed `HTTP_PROXY_DNS_TARGET_IP` propagates quickly instead of being cached by the OS stub resolver ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ The proxy uses **opt-in container discovery** (`exposedByDefault: false`). Only 
 
 Unmanaged containers are ignored and never exposed.
 
+One-off containers created by `docker compose run` are also ignored, even when they inherit `VIRTUAL_HOST` from the service definition. They are labelled `com.docker.compose.oneoff=True` by Compose, and routing them would let a short-lived container claim the domain of the long-running service. Use `docker compose up` for containers that must be reachable through the proxy.
+
 ## Network Management
 
 The proxy automatically joins Docker networks that contain manageable containers, enabling seamless routing without manual network configuration. This process is handled by the `join-networks` service.

--- a/cmd/dinghy-layer/main.go
+++ b/cmd/dinghy-layer/main.go
@@ -229,6 +229,17 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		return "", nil
 	}
 
+	// Skip one-off containers created by "docker compose run". They inherit
+	// VIRTUAL_HOST from the service definition, so routing them would make a
+	// short-lived container compete with the service for the same domain.
+	if utils.IsComposeOneOff(inspect.Config.Labels) {
+		cl.logger.Info("Skipping one-off compose container",
+			"container_id", utils.FormatDockerID(containerID),
+			"container_name", containerInfo.Name,
+			"virtual_host", containerInfo.VirtualHost)
+		return "", nil
+	}
+
 	// Skip if traefik labels are already set; native labels take precedence and
 	// Traefik's Docker provider handles those containers directly.
 	if utils.HasTraefikLabel(inspect.Config.Labels) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -186,9 +186,22 @@ func HasTraefikLabel(labels map[string]string) bool {
 	return false
 }
 
+// IsComposeOneOff reports whether the container was created by "docker compose run".
+// Compose labels those containers with com.docker.compose.oneoff=True, while
+// containers created by "docker compose up" carry the same label set to False.
+// One-off containers inherit VIRTUAL_HOST from the service definition, so routing
+// them would let a short-lived container claim the service domain.
+func IsComposeOneOff(labels map[string]string) bool {
+	return strings.EqualFold(labels["com.docker.compose.oneoff"], "true")
+}
+
 // ShouldManageContainer checks if a container should be managed based on dinghy env vars or traefik labels
 // Returns true if the container has VIRTUAL_HOST environment variable or traefik labels
 func ShouldManageContainer(env []string, labels map[string]string) bool {
+	if IsComposeOneOff(labels) {
+		return false
+	}
+
 	// Check for dinghy VIRTUAL_HOST environment variable
 	if GetDockerEnvVar(env, "VIRTUAL_HOST") != "" {
 		return true

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -51,6 +51,9 @@ func TestShouldManageContainer(t *testing.T) {
 		{"virtual host", []string{"VIRTUAL_HOST=app.loc"}, nil, true},
 		{"traefik label", nil, map[string]string{"traefik.enable": "true"}, true},
 		{"both", []string{"VIRTUAL_HOST=app.loc"}, map[string]string{"traefik.enable": "true"}, true},
+		{"oneoff virtual host", []string{"VIRTUAL_HOST=app.loc"}, map[string]string{"com.docker.compose.oneoff": "True"}, false},
+		{"oneoff traefik label", nil, map[string]string{"com.docker.compose.oneoff": "True", "traefik.enable": "true"}, false},
+		{"not oneoff", []string{"VIRTUAL_HOST=app.loc"}, map[string]string{"com.docker.compose.oneoff": "False"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -41,6 +41,7 @@ VIRTUAL_HOST_CONTAINER="test-virtual-host-app"
 VIRTUAL_HOST_PORT_CONTAINER="test-virtual-host-port-app"
 MULTI_VIRTUAL_HOST_CONTAINER="test-multi-virtual-host-app"
 ORPHAN_CONTAINER="test-orphan-reconcile-app"
+ONEOFF_CONTAINER="test-oneoff-app"
 
 # Hostname configurations for DNS testing
 TRAEFIK_HOSTNAME="app1.${TEST_DOMAIN}"
@@ -49,6 +50,7 @@ VIRTUAL_HOST_PORT_HOSTNAME="app3.${TEST_DOMAIN}"
 MULTI_VIRTUAL_HOST_HOSTNAME1="app4.${TEST_DOMAIN}"
 MULTI_VIRTUAL_HOST_HOSTNAME2="app5.${TEST_DOMAIN}"
 ORPHAN_HOSTNAME="app6.${TEST_DOMAIN}"
+ONEOFF_HOSTNAME="app7.${TEST_DOMAIN}"
 
 # Logging function
 log() {
@@ -215,6 +217,40 @@ test_orphan_config_reconciliation() {
     success "Recreated container config and shared files survived reconciliation"
 
     docker rm -f "$ORPHAN_CONTAINER" >/dev/null 2>&1 || true
+    return 0
+}
+
+# Test that one-off containers created by "docker compose run" are ignored
+# (issue #111). Compose marks them with com.docker.compose.oneoff=True and they
+# inherit VIRTUAL_HOST from the service, so routing them would let a short-lived
+# container claim the service domain.
+test_oneoff_container_ignored() {
+    docker run -d --name "$ONEOFF_CONTAINER" \
+        --label "com.docker.compose.oneoff=True" \
+        --env "VIRTUAL_HOST=${ONEOFF_HOSTNAME}" nginx:alpine
+    wait_for_container "$ONEOFF_CONTAINER" || return 1
+    wait_with_message "$SLEEP_PROXY_CONFIG" "for proxy configuration to propagate"
+
+    local container_id
+    container_id=$(docker inspect --format '{{.Id}}' "$ONEOFF_CONTAINER" | cut -c1-12)
+    if docker exec http-proxy test -f "/traefik/dynamic/${container_id}.yaml"; then
+        error "Config file ${container_id}.yaml was generated for a one-off container"
+        docker rm -f "$ONEOFF_CONTAINER" >/dev/null 2>&1 || true
+        return 1
+    fi
+    success "No config file was generated for the one-off container"
+
+    local status
+    status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+        -H "Host: ${ONEOFF_HOSTNAME}" "http://localhost:${HTTP_PORT}" 2>/dev/null || echo "000")
+    if [ "$status" != "404" ]; then
+        error "Expected 404 for ${ONEOFF_HOSTNAME}, got ${status}"
+        docker rm -f "$ONEOFF_CONTAINER" >/dev/null 2>&1 || true
+        return 1
+    fi
+    success "One-off container domain ${ONEOFF_HOSTNAME} is not routed"
+
+    docker rm -f "$ONEOFF_CONTAINER" >/dev/null 2>&1 || true
     return 0
 }
 
@@ -628,7 +664,7 @@ test_with_dns_config() {
 
 # Cleanup test containers
 cleanup() {
-    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" "$ORPHAN_CONTAINER" 2>/dev/null || true
+    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" "$ORPHAN_CONTAINER" "$ONEOFF_CONTAINER" 2>/dev/null || true
 }
 
 # Full stack cleanup and rebuild
@@ -719,6 +755,13 @@ main() {
     test_orphan_config_reconciliation && orphan_passed=1
     [ "$orphan_passed" -eq 1 ] && passed=$((passed + 1))
 
+    # One-off compose container test (issue #111)
+    log "Testing one-off compose containers are ignored..."
+    total=$((total + 1))
+    local oneoff_passed=0
+    test_oneoff_container_ignored && oneoff_passed=1
+    [ "$oneoff_passed" -eq 1 ] && passed=$((passed + 1))
+
     # DNS Tests (if dig available)
     if command -v dig >/dev/null 2>&1; then
         log "Testing DNS functionality..."
@@ -744,6 +787,7 @@ main() {
     log "HTTP Tests: ${http_passed}/5 passed"
     log "HSTS Tests: ${hsts_passed}/5 passed"
     log "Orphan Reconciliation Tests: ${orphan_passed}/1 passed"
+    log "One-off Container Tests: ${oneoff_passed}/1 passed"
     log "Test Suites: ${passed}/${total} passed"
 
     cleanup


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Containers created by `docker compose run` inherit the service environment, including `VIRTUAL_HOST` and `VIRTUAL_PORT`. The dinghy layer wrote a dynamic configuration file for them, so a one-off container declared a router for the domain of the long-running service it was started from.

Two routers with the same `Host()` rule made the winner unpredictable. When the one-off container ran a different command than the service, the generated backend pointed at a port nothing listened on and Traefik answered `502 Bad Gateway`.

Compose labels those containers with `com.docker.compose.oneoff=True`, and containers created by `docker compose up` carry the same label set to `False`.

Changes:

- **`pkg/utils`** adds `IsComposeOneOff`, and `ShouldManageContainer` now returns false for one-off containers, which also removes them from the network joiner's manageable set.
- **`cmd/dinghy-layer`** skips one-off containers in `processContainer` and logs the skip at INFO, so an unrouted `docker compose run` is visible in the logs.
- **`test/test.sh`** asserts that a container labelled `com.docker.compose.oneoff=True` with a `VIRTUAL_HOST` gets no config file and that its domain returns `404`.
- **`README.md`** and **`CHANGELOG.md`** document the behaviour.

Unit tests cover the label check for the `True`, `False`, and absent cases. `gofmt`, `go vet`, and `go test ./...` pass locally. The integration suite has not been run locally because it tears down the `http-proxy` compose project, which would stop the installed proxy on the development machine. CI runs it on this branch.

Closes #111


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Ignore Compose one-off containers during routing.

- Exclude one-offs from network management.

- Add unit and integration coverage.

- Document one-off container behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OneOff["Compose one-off container"]
  Filter["One-off label filter"]
  Routing["Dynamic route generation"]
  Networks["Network management"]
  OneOff -- "is identified by label" --> Filter
  Filter -- "prevents configuration" --> Routing
  Filter -- "excludes container" --> Networks
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Skip one-off containers during route processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/dinghy-layer/main.go

<ul><li>Detect containers labelled <code>com.docker.compose.oneoff=True</code>.<br> <li> Skip dynamic configuration generation for Compose one-offs.<br> <li> Log skipped one-off containers at INFO level.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-6f7909d862402f3a0dd82ff94d73a0a7d2ebbbea860b2fd0e2f399338450dc06">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Filter Compose one-offs from managed containers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils.go

<ul><li>Add <code>IsComposeOneOff</code> helper with case-insensitive matching.<br> <li> Exclude Compose one-offs in <code>ShouldManageContainer</code>.<br> <li> Prevent one-offs from being considered for network joining.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_test.go</strong><dd><code>Test one-off container management filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils_test.go

<ul><li>Verify one-offs with <code>VIRTUAL_HOST</code> are unmanaged.<br> <li> Verify one-offs with Traefik labels are unmanaged.<br> <li> Verify <code>com.docker.compose.oneoff=False</code> remains manageable.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-dbb00af8f58edf5a904cecaf0c5eb4c07979ce8711d22f826bfd70ce5e9634c9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.sh</strong><dd><code>Add one-off routing integration coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test.sh

<ul><li>Add an integration test container labelled as a Compose one-off.<br> <li> Assert no dynamic Traefik configuration file is created.<br> <li> Assert the inherited virtual host returns <code>404</code>.<br> <li> Include the one-off test in cleanup and results.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-68dc634ad3d79412c7330c0a047395557852ea0c6ab031596194f56aa1444104">+45/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document one-off container routing fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Record the fix for ignored Compose one-off containers.<br> <li> Explain prevention of conflicting domains and <code>502</code> backends.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Explain one-off container discovery behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document that <code>docker compose run</code> containers are ignored.<br> <li> Recommend <code>docker compose up</code> for proxy-routable services.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/112/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra