### PR TITLE
docs(openspec): specify VIRTUAL_PATH routing

### DIFF
--- a/openspec/changes/virtual-path-routing/.openspec.yaml
+++ b/openspec/changes/virtual-path-routing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/virtual-path-routing/design.md
+++ b/openspec/changes/virtual-path-routing/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`dinghy_layer` watches Docker events and translates `VIRTUAL_HOST` and `VIRTUAL_PORT` into Traefik dynamic configuration files. Per container it emits one router per hostname entry, a TLS twin of each, and one service.
+
+Four properties of the existing code shape the decisions below.
+
+**A container has one backend port.** `getEffectivePort` runs once per container and returns the first entry naming a port, applied to the single service the container gets. `VIRTUAL_HOST=a.loc:3000,b.loc:4000` already routes both hostnames to 3000. Pre-existing and not changed here.
+
+**A hostname entry can be a plain name, a wildcard, or a `~`-prefixed regex** handed to Traefik as-is.
+
+**A container carrying any `traefik.` label is skipped entirely.** `HasTraefikLabel` matches on the prefix, so a middleware-only label suppresses `VIRTUAL_HOST` too. `examples/applications.yml` Example 7 is broken today for exactly this reason.
+
+**No router this layer emits sets a priority.** Traefik therefore orders them all by rule length, together with every router its Docker provider builds from user labels, in one table per entrypoint.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A container is reachable on a path of a hostname another container serves.
+- The path behaves as a path prefix does in a deployed environment, so one relative call works in both places.
+- Which container answers a request is unambiguous among the routes this layer generates.
+- A declaration that cannot work is reported where a user will see it.
+
+**Non-Goals:**
+
+- Rewriting or stripping the path before the backend sees it.
+- Per-entry backend ports. The one-port-per-container behaviour is documented, not changed.
+- Changing how any container without `VIRTUAL_PATH` is routed.
+- Replacing native routing labels, which can express all of this and remain available.
+
+## Decisions
+
+**A separate variable, not a path inside the hostname.**
+
+`VIRTUAL_PATH` is what `nginx-proxy` uses for this. Beyond precedent it avoids three problems: the hostname parser is untouched, so a `~` regex cannot have a slash reinterpreted as a path; each container keeps its own `VIRTUAL_PORT`, so nothing implies per-entry ports the single service cannot deliver; and it is a variable the current code does not read, so no existing configuration can change behaviour.
+
+The alternative, `VIRTUAL_HOST=host/path`, was considered first and rejected on those three counts.
+
+Note for the compatibility documentation: `VIRTUAL_PATH` comes from `nginx-proxy`, not from `codekitchen/dinghy-http-proxy`, which never had it. The existing table describes the latter, so the new variable needs its own note rather than a row implying dinghy supported it.
+
+**The matcher pairs a prefix with an exact match.**
+
+Traefik's `PathPrefix` is a raw string prefix: `PathPrefix(/api)` also matches `/api-docs`. A deployed `pathType: Prefix` splits on separators and does not. Since the point of the feature is that one relative call behaves the same in both places, the local matcher has to agree:
+
+```
+Host(`app.loc`) && (PathPrefix(`/api/`) || Path(`/api`))
+```
+
+A trailing separator is normalised away before the rule is built, so `/api` and `/api/` are one declaration.
+
+**Priority is set on path routers only, and on nothing else.**
+
+This is the decision that keeps the change additive. Setting a priority on the existing hostname routers would re-rank them against every router on the machine, including ones built from user labels by a different provider, since Traefik sorts a single table per entrypoint. That is a behaviour change for people who never asked for this feature, and it would replace today's accidental-but-stable ordering between exact and wildcard hosts with an undefined tie.
+
+So hostname routers keep inheriting rule-length ordering exactly as they do now, and only the routers a `VIRTUAL_PATH` produces carry an explicit value. That value sits far above any rule-length default, which is bounded by how long a rule string can plausibly be, and grows with the path's length so a longer path outranks a shorter one on the same hostname. Both the HTTP and HTTPS routers of one path get the same value.
+
+Two consequences worth stating. The field must serialise: a zero value with `omitempty` would be dropped and silently restore inherited ordering, so the chosen floor is non-zero and the test asserts the emitted configuration rather than the struct. And a user who sets a higher priority on their own label wins, deliberately, which is why the requirement is scoped to the routes this layer generates.
+
+**Nothing is stripped.**
+
+The backend receives the path as sent. This matches a deployed Ingress and `nginx-proxy`'s own default, where the companion `VIRTUAL_DEST` is empty. `VIRTUAL_DEST` is out of scope; stripping can be added later behind it, un-stripping could not.
+
+**A path applies to every hostname the container declares.**
+
+`VIRTUAL_PATH` belongs to the container, as `VIRTUAL_PORT` does. A container naming two hostnames and one path is mounted at that path on both. The alternative, aligning a list of paths positionally with a list of hostnames, is a syntax nobody can read back correctly, which is also why a separator inside `VIRTUAL_PATH` is rejected rather than treated as a list.
+
+**Duplicates are detected from a running index, not only at startup.**
+
+Two containers claiming the same path on the same hostname is a mistake with an arbitrary outcome. Detecting it only during the initial scan would miss the normal case, because developers start the proxy first and their stack afterwards, so both containers arrive as live events. The layer therefore keeps what it has already seen, keyed by hostname and path, and reports a collision whichever way the second container arrives. The same index catches two containers claiming a hostname's root.
+
+**Reports are visible by default.**
+
+The existing skip paths log at debug, which is off at the default level, so a user would see nothing. Every report this change introduces is emitted at a level a user running the proxy normally will see, otherwise the requirement to report is satisfied by something nobody reads.
+
+**Certificates stay per hostname.**
+
+A path adds no hostname, so it needs no certificate and is served by the one already covering its host. The certificate commands reject an argument containing a path: today the filename helper maps a separator to an underscore, so such a request half-succeeds instead of being refused.
+
+## Risks / Trade-offs
+
+- **A stopped container changes what a path returns rather than breaking it.** When the container serving a path stops, its routes go with it and requests under that path fall through to whatever serves the hostname. For a development server that means a page and a `200`, not a 404, which is confusing to debug. A deployed Ingress behaves the same way. Documented, pinned by a test, and the reason the self-diagnosis compares response content rather than status.
+
+- **`VIRTUAL_PATH` with a `traefik.` label does nothing, and that is pre-existing.** The container is skipped whole. A path is exactly when someone reaches for a middleware label, so this change makes an existing trap easier to fall into. Reporting it is the mitigation; changing the skip rule is a larger decision and out of scope. The broken shipped example is fixed so it stops teaching the trap.
+
+- **Router names can still collide.** Names derive from a sanitised container name, and the sanitisation is lossy, so two differently-named containers can produce one name and the file provider drops one. Pre-existing, unchanged, and made easier to reach now that sharing a hostname is normal.
+
+- **Path validation is a security boundary.** The rule is built by string formatting, so a path containing a backtick could close the matcher and append arbitrary routing syntax. Validation rejects anything that is not a single plain path, and that is the reason, not tidiness.
+
+- **The integration suite's readiness check needs a container with a shell.** It probes readiness by executing a command inside the container, so an image without one can never become ready. The obvious image for distinguishing two backends by response content does not have a shell, so the test containers must either be images that do, or serve distinguishable content from an image that does.

--- a/openspec/changes/virtual-path-routing/proposal.md
+++ b/openspec/changes/virtual-path-routing/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A container can only ask for a whole hostname. There is no way to be routed on a path of a hostname another container already serves, so a browser-served frontend and its API cannot share one origin locally.
+
+That matters because sharing an origin is what removes CORS, preflight requests and a second credential. A deployed environment gets this from an Ingress sending a path prefix to a different Service. Locally the same application code has to reach for an environment-dependent API address, or each framework's development server grows a hand-written proxy rule that duplicates the deployed routing and drifts from it.
+
+## What Changes
+
+**`VIRTUAL_PATH` mounts a container under a path of its `VIRTUAL_HOST`.** Both containers name the same hostname; the one being mounted under a path adds `VIRTUAL_PATH=/api`. This is the variable [nginx-proxy uses for the same purpose](https://github.com/nginx-proxy/nginx-proxy/blob/main/docs/README.md), and this layer exists to be compatible with that style of container.
+
+**The path matcher is segment-aware.** Traefik's `PathPrefix` is a raw string prefix, so `PathPrefix(/api)` also matches `/api-docs`. An Ingress `pathType: Prefix` splits on separators and does not. The generated rule pairs `PathPrefix` with `Path` so a path never captures a sibling that merely starts with the same characters.
+
+**Only the new routes carry an explicit priority.** Traefik orders routers by rule length when priority is unset, across providers, in one table per entrypoint. Setting a priority on the hostname routers this layer already emits would re-rank them against routers built from users' own labels, so they are left exactly as they are and only the routes a path produces are ranked explicitly.
+
+**Nothing is stripped.** The backend receives the request path unchanged, matching both an Ingress and nginx-proxy's own default.
+
+**`VIRTUAL_HOST` parsing is untouched**, so no existing configuration changes behaviour and each container keeps its own `VIRTUAL_PORT`.
+
+**Declarations that cannot work are reported at a level users see**, including two that are silent today: a container carrying a `traefik.` label, which is skipped whole, and a path with no hostname to sit on.
+
+## Capabilities
+
+### New Capabilities
+
+- `virtual-path-routing`: a container is routed on a path of a hostname another container serves, through the same environment-variable interface used to expose a whole hostname.
+
+### Modified Capabilities
+
+None. This is the first change tracked here, so there are no existing specs to modify. The behaviour of containers that do not set `VIRTUAL_PATH` is deliberately unchanged, which is why priority is set on the new routes only.
+
+## Impact
+
+- `cmd/dinghy-layer`: reads the new variable, validates it, builds the path rule, sets priority on the routers it produces, and keeps enough state across events to spot two containers claiming one path.
+- `pkg/config`: the router struct gains the priority field it currently lacks, serialising with a non-zero floor so it cannot be dropped.
+- `pkg/utils`: unchanged. A container using a path still sets `VIRTUAL_HOST`, so the check deciding whether a container is managed keeps working, and network joining is unaffected.
+- `bin/spark-http-proxy`: certificate commands reject an argument containing a path, and the self-diagnosis command checks a mounted path by response content, since a missing path route falls through to the hostname's container and still answers `200`.
+- `cmd/dinghy-layer/main_test.go`: cases for every accepted and rejected form, the rule and the emitted router asserted whole, and the precedence ordering pinned.
+- `test/test.sh`: containers sharing a hostname, each route proved by distinct content, plus the wildcard, sibling-prefix and container-stops cases. Its container names, creation, waits, counters, printed results and cleanup are all maintained by hand and need updating together.
+- `README.md`: the variable in the supported patterns, in the configuration example, and in the compatibility notes, where it is attributed to nginx-proxy rather than to the dinghy proxy that table describes, and where `VIRTUAL_DEST` is recorded as unsupported.
+- `examples/`: a runnable two-container example, and a fix to the existing example that is dead today because a middleware label suppresses its `VIRTUAL_HOST`.
+- `AGENTS.md`: the new variable, plus corrections to its claims that the repository has no unit tests and that the make target runs them.
+- `CHANGELOG.md`: an entry, as the contributor guide requires.
+- The agent skill for this proxy, which `AGENTS.md` points at for consumers. It lives in a separate repository, so it is a separate pull request, raised once this change is released.
+- Existing users: no action. The variable is new, and configurations that do not set it are routed exactly as before.

--- a/openspec/changes/virtual-path-routing/specs/virtual-path-routing/spec.md
+++ b/openspec/changes/virtual-path-routing/specs/virtual-path-routing/spec.md
@@ -1,0 +1,240 @@
+## Purpose
+
+Let a container be routed on a path of a hostname another container already serves, through `VIRTUAL_PATH`, so applications that must share one origin can do so locally with the same environment-variable interface used to expose a whole hostname.
+
+## ADDED Requirements
+
+### Requirement: VIRTUAL_PATH mounts a container under a path of its hostname
+
+A container setting `VIRTUAL_PATH` alongside `VIRTUAL_HOST` SHALL receive requests for that path on that hostname. Requests outside the path SHALL continue to reach whichever container serves the hostname itself.
+
+#### Scenario: Two containers share one hostname
+
+- **WHEN** one container sets `VIRTUAL_HOST=app.loc` and another sets `VIRTUAL_HOST=app.loc` with `VIRTUAL_PATH=/api`
+- **THEN** a request for `/api` reaches the second container
+- **AND** a request for `/` reaches the first
+
+#### Scenario: The backend sees the path unchanged
+
+- **WHEN** a request for `/api/users` reaches a container mounted at `/api`
+- **THEN** the container receives `/api/users`, with nothing removed
+
+#### Scenario: Both schemes reach the same container
+
+- **WHEN** a request for a mounted path arrives over HTTP, and the same request arrives over HTTPS
+- **THEN** both reach the mounted container
+
+#### Scenario: The container keeps its own port
+
+- **WHEN** a container mounted under a path sets `VIRTUAL_PORT`
+- **THEN** that port is used for it, whatever port any other container on the hostname sets
+
+#### Scenario: VIRTUAL_PATH applies to every hostname the container declares
+
+- **WHEN** a container sets `VIRTUAL_HOST=a.loc,b.loc` with `VIRTUAL_PATH=/api`
+- **THEN** it is mounted at `/api` on both hostnames
+
+### Requirement: A path matches on whole segments
+
+`VIRTUAL_PATH` SHALL match its own path and anything beneath it, and SHALL NOT match a sibling path that merely begins with the same characters.
+
+#### Scenario: The path itself and its children
+
+- **WHEN** a container is mounted at `/api`
+- **THEN** a request for `/api` reaches it
+- **AND** so does a request for `/api/users`
+
+#### Scenario: A sibling sharing the prefix
+
+- **WHEN** a container is mounted at `/api` and a request names `/api-docs`
+- **THEN** it does not reach the mounted container
+
+#### Scenario: A trailing separator makes no difference
+
+- **WHEN** a container sets `VIRTUAL_PATH=/api` and another sets `VIRTUAL_PATH=/api/`
+- **THEN** the two declarations route identically
+
+### Requirement: A mounted path wins against the routes this proxy generates
+
+A mounted path SHALL take precedence over every other route this proxy generates that would otherwise match the same request. Precedence SHALL be stated on the mounted path's routes rather than left to be inferred.
+
+Routes a user writes directly as Traefik labels are outside this requirement, because a user can set any precedence there deliberately.
+
+#### Scenario: Against the hostname's own route
+
+- **WHEN** `app.loc` is served by one container and `/api` on it by another
+- **THEN** requests under `/api` reach the mounted container
+
+#### Scenario: Against a wildcard covering the same hostname
+
+- **WHEN** another container declares a wildcard hostname that also matches `app.loc`
+- **THEN** requests under `/api` still reach the mounted container
+
+#### Scenario: A longer path against a shorter one
+
+- **WHEN** one container is mounted at `/api` and another at `/api/internal` on the same hostname
+- **THEN** a request for `/api/internal/x` reaches the second
+
+#### Scenario: Both of a mounted path's routes rank together
+
+- **WHEN** a container is mounted under a path
+- **THEN** its HTTP and HTTPS routes carry the same precedence, so the two schemes cannot order differently
+
+### Requirement: Existing declarations are untouched
+
+Adding `VIRTUAL_PATH` SHALL NOT change the routing of any container that does not set it.
+
+#### Scenario: A container declaring only a hostname
+
+- **WHEN** a container sets `VIRTUAL_HOST` and no `VIRTUAL_PATH`
+- **THEN** its generated routes are unchanged, including how they rank against every other route on the machine
+
+#### Scenario: A hostname that is a wildcard or a pattern
+
+- **WHEN** a container declares a wildcard or a `~`-prefixed pattern hostname
+- **THEN** it keeps being interpreted as such, whether or not `VIRTUAL_PATH` is set
+
+#### Scenario: A container using a path is still managed
+
+- **WHEN** a container sets `VIRTUAL_PATH`
+- **THEN** it is managed, and its network is joined, on the same terms as any other exposed container
+
+### Requirement: A declaration that cannot work is reported
+
+A declaration that cannot produce a working route SHALL be reported where a user running the proxy normally will see it, and SHALL NOT silently produce a route that never matches or a rule the declaration did not intend.
+
+#### Scenario: VIRTUAL_PATH without VIRTUAL_HOST
+
+- **WHEN** a container sets `VIRTUAL_PATH` and no `VIRTUAL_HOST`
+- **THEN** it is reported, naming the container, because the path has no hostname to sit on and the container is not exposed at all
+
+#### Scenario: VIRTUAL_PATH alongside a Traefik label
+
+- **WHEN** a container sets `VIRTUAL_PATH` and also carries any `traefik.` label
+- **THEN** it is reported, because such a container is skipped entirely and neither its hostname nor its path is routed
+
+#### Scenario: A malformed path
+
+- **WHEN** `VIRTUAL_PATH` is not a single plain path beginning with a separator
+- **THEN** it is rejected and reported, naming what was wrong
+
+#### Scenario: A path carrying routing syntax
+
+- **WHEN** `VIRTUAL_PATH` contains characters that would otherwise be read as routing syntax
+- **THEN** it is rejected, and no route is produced from it
+
+#### Scenario: A list where one path is expected
+
+- **WHEN** `VIRTUAL_PATH` contains a separator between several paths, as `VIRTUAL_HOST` accepts for hostnames
+- **THEN** it is rejected and reported, rather than accepted as one path that can never match
+
+#### Scenario: Two containers claiming one path
+
+- **WHEN** two containers claim the same path on the same hostname, whether they were both present at startup or the second arrived later
+- **THEN** it is reported, naming both, because which one answers would otherwise be arbitrary
+
+### Requirement: A path addressing the whole hostname is a hostname declaration
+
+`VIRTUAL_PATH` naming the root SHALL be treated as though it were absent, rather than producing a second route for the whole hostname.
+
+#### Scenario: The root path
+
+- **WHEN** a container sets `VIRTUAL_PATH=/`
+- **THEN** it is routed as though only `VIRTUAL_HOST` were set
+
+### Requirement: A path needs no certificate of its own
+
+Certificate handling SHALL remain per hostname. A request to create or remove a certificate for a path SHALL be refused with an explanation.
+
+#### Scenario: A certificate covers the paths on its hostname
+
+- **WHEN** a hostname has a certificate and a container is mounted under a path of it
+- **THEN** the mounted path is served over HTTPS, and no further certificate is created
+
+#### Scenario: Asking for a certificate for a path
+
+- **WHEN** someone asks to generate or remove a certificate for an argument containing a path
+- **THEN** the request is refused, and the message says a certificate covers a hostname
+
+### Requirement: The hostname's own container is not required
+
+A path SHALL be routable whether or not another container currently serves the hostname it sits on.
+
+#### Scenario: No container serves the hostname
+
+- **WHEN** a container is mounted at `/api` on a hostname nothing else serves
+- **THEN** requests under `/api` reach it, and requests for `/` are not found
+
+#### Scenario: The mounted container stops
+
+- **WHEN** the container serving `/api` stops while the hostname's own container keeps running
+- **THEN** requests under `/api` reach the hostname's container instead, as they would if the path had never been declared
+
+### Requirement: The shipped diagnostic exercises a path
+
+The self-diagnosis command SHALL verify that a mounted path is answered by the container mounted there, distinguishing it from the container serving the hostname.
+
+#### Scenario: The diagnostic checks a path
+
+- **WHEN** a user runs the self-diagnosis command
+- **THEN** it starts a container on a hostname and another mounted under a path of it
+- **AND** it asserts that a request under the path is answered by the mounted container, identified by its response content rather than only its status
+
+#### Scenario: A status code alone is not enough
+
+- **WHEN** the mounted container's route is missing and the request falls through to the hostname's container
+- **THEN** the diagnosis fails, because the response did not come from the container it asked for
+
+#### Scenario: The diagnostic cleans up after itself
+
+- **WHEN** the diagnosis finishes, whether it passed or failed
+- **THEN** every container it started is removed
+
+### Requirement: The capability is documented where the existing variables are
+
+`VIRTUAL_PATH` SHALL appear wherever `VIRTUAL_HOST` and `VIRTUAL_PORT` are already described, with a worked example, and what is deliberately unsupported SHALL be stated.
+
+#### Scenario: A reader looks up how to expose a container
+
+- **WHEN** someone reads the documentation of the environment variables a container can set
+- **THEN** `VIRTUAL_PATH` is listed alongside them, with what it does and how it combines with `VIRTUAL_HOST`
+
+#### Scenario: A reader wants a working example
+
+- **WHEN** someone runs the shipped examples
+- **THEN** one shows two containers sharing a hostname, one at the root and one under a path, and it works as written
+
+#### Scenario: A reader comes from the projects this layer is compatible with
+
+- **WHEN** someone reads the compatibility notes
+- **THEN** `VIRTUAL_PATH` is recorded as borrowed from `nginx-proxy` rather than from `codekitchen/dinghy-http-proxy`, which never had it
+- **AND** `VIRTUAL_DEST`, the `nginx-proxy` companion that rewrites the path, is recorded as unsupported
+
+#### Scenario: A reader needs the edge cases
+
+- **WHEN** someone reads about `VIRTUAL_PATH`
+- **THEN** it states that nothing is stripped, that a certificate covers a hostname, that `VIRTUAL_PORT` belongs to the container, that a `traefik.` label on the same container disables both variables, and what the paths return once the mounted container stops
+
+### Requirement: The agent skill for this proxy teaches the new variable
+
+The companion skill agents load when asked to expose a container SHALL cover `VIRTUAL_PATH`, so an agent asked to put two applications on one hostname reaches for it rather than inventing routing labels.
+
+#### Scenario: An agent is asked to expose a container under a path
+
+- **WHEN** an agent working from the skill is asked to serve an application under a path of a hostname another container already uses
+- **THEN** the skill gives it `VIRTUAL_PATH`, with a worked compose example
+
+#### Scenario: The skill's summary of accepted forms
+
+- **WHEN** an agent reads the skill's table of what `VIRTUAL_HOST` accepts
+- **THEN** `VIRTUAL_PATH` appears alongside it, marked as a separate variable rather than another hostname form
+
+#### Scenario: The skill's triggers
+
+- **WHEN** a user mentions `VIRTUAL_PATH`, or asks for one origin, or asks why a path is not routing locally
+- **THEN** the skill is selected, because its description names those signals
+
+#### Scenario: The skill's troubleshooting
+
+- **WHEN** an agent is asked why a path reaches the wrong container
+- **THEN** the skill covers it, including the stopped-container fall-through and the `traefik.` label case

--- a/openspec/changes/virtual-path-routing/tasks.md
+++ b/openspec/changes/virtual-path-routing/tasks.md
@@ -1,0 +1,97 @@
+## 1. Read the declaration
+
+- [ ] 1.1 `VIRTUAL_PATH` is read from a container alongside `VIRTUAL_HOST` and `VIRTUAL_PORT`
+- [ ] 1.2 A container without `VIRTUAL_PATH` produces byte-identical configuration to what it produces today
+- [ ] 1.3 A trailing separator is normalised away, so `/api` and `/api/` are one declaration
+- [ ] 1.4 `VIRTUAL_PATH=/` is treated as though the variable were absent
+- [ ] 1.5 A value that is not a single plain path beginning with a separator is rejected, reported, and leaves the container's hostname routes intact
+- [ ] 1.6 A value containing a separator between several paths is rejected rather than accepted as one unmatchable path
+- [ ] 1.7 A value containing characters that would be read as routing syntax is rejected, covered by a test that fails if the check is removed
+
+## 2. Build the route
+
+- [ ] 2.1 A declared path produces a route matching that path and everything beneath it, on every hostname the container declares
+- [ ] 2.2 The route does not match a sibling path that merely begins with the same characters
+- [ ] 2.3 The backend receives the request path unchanged
+- [ ] 2.4 The path route and its secure twin are both produced, as the hostname routes already are
+- [ ] 2.5 The container's own port is used, whatever port another container on the hostname declares
+- [ ] 2.6 A wildcard or `~`-pattern hostname keeps its meaning when a path is declared with it
+
+## 3. Make precedence deterministic without disturbing what exists
+
+- [ ] 3.1 The router type carries a precedence field that serialises, with a non-zero floor, so it cannot be dropped and silently restore inherited ordering
+- [ ] 3.2 Only the routes a declared path produces carry an explicit precedence; hostname routes are emitted exactly as before
+- [ ] 3.3 A path route outranks the route for the hostname it sits on
+- [ ] 3.4 A path route outranks a wildcard route that also matches the hostname
+- [ ] 3.5 A longer path outranks a shorter one on the same hostname
+- [ ] 3.6 A path's HTTP and HTTPS routes carry the same precedence
+- [ ] 3.7 A test asserts the emitted configuration, not the struct, so the field cannot silently stop serialising
+- [ ] 3.8 A test asserts that a container without a path emits no precedence at all
+
+## 4. Report what cannot work
+
+- [ ] 4.1 Every report this change introduces is emitted at a level visible at the default setting
+- [ ] 4.2 `VIRTUAL_PATH` with no `VIRTUAL_HOST` is reported, naming the container
+- [ ] 4.3 `VIRTUAL_PATH` on a container carrying any `traefik.` label is reported, since the container is skipped whole
+- [ ] 4.4 A rejected path says what was wrong with it
+- [ ] 4.5 Two containers claiming the same path on one hostname are reported, naming both
+- [ ] 4.6 The collision is detected whether both containers were present at startup or the second arrived later, which needs state carried across events rather than a single scan
+
+## 5. Keep certificates about hostnames
+
+- [ ] 5.1 A path is served over HTTPS by the certificate already covering its hostname, with nothing further created
+- [ ] 5.2 Generating a certificate for an argument containing a path is refused, with a message saying a certificate covers a hostname
+- [ ] 5.3 Removing one is refused the same way
+- [ ] 5.4 The refusal is checked, since the filename helper currently maps a separator to an underscore and lets such a request half-succeed
+
+## 6. Documentation a reader will actually find
+
+- [ ] 6.1 `VIRTUAL_PATH` is listed wherever the existing container variables are described, with what it does
+- [ ] 6.2 The supported-patterns section shows it, marked as a separate variable rather than another hostname form
+- [ ] 6.3 A runnable example shows two containers sharing one hostname, one at the root and one under a path
+- [ ] 6.4 The compatibility notes record it as borrowed from `nginx-proxy` rather than from the dinghy proxy the table describes, and record `VIRTUAL_DEST` as unsupported
+- [ ] 6.5 The documentation states that nothing is stripped, that a certificate covers a hostname, that the port belongs to the container, that a `traefik.` label disables both variables, and what the paths return once the mounted container stops
+- [ ] 6.6 A line says that changing the variable needs the container recreated, since environment variables cannot change in place
+- [ ] 6.7 The contributor guide gains the variable, and two of its claims are corrected: that the repository has no unit tests, and that the make target runs them
+- [ ] 6.8 The shipped example that is already dead, because a middleware label suppresses its `VIRTUAL_HOST`, is fixed rather than left teaching the trap
+- [ ] 6.9 Every example added or touched is checked by running it
+- [ ] 6.10 A changelog entry, as the contributor guide requires
+
+## 7. The agent skill for this proxy
+
+Lands in the companion skills repository the contributor guide points at, and
+therefore as its own pull request.
+
+- [ ] 7.1 The skill's container-exposure reference covers the variable, with a worked compose example of two containers on one hostname
+- [ ] 7.2 It appears in the skill's summary of accepted forms, marked as a separate variable
+- [ ] 7.3 The skill's description names the signals that should select it: the variable, one origin, a path that is not routing locally
+- [ ] 7.4 The skill's troubleshooting covers a path reaching the wrong container, the stopped-container fall-through, and the `traefik.` label case
+- [ ] 7.5 The skill states what the proxy does not do: nothing is stripped, a certificate covers a hostname, the port belongs to the container
+- [ ] 7.6 Raised only once the proxy change is released, so the skill never describes a version nobody can run
+
+## 8. Cover the parsing and rule building directly
+
+- [ ] 8.1 Every accepted and rejected form has a case: absent, root-only, trailing separator, no leading separator, a list, and routing syntax
+- [ ] 8.2 The generated rule is asserted whole, not by substring, so a change to the matcher cannot pass unnoticed
+- [ ] 8.3 The emitted router is asserted whole, so precedence and its absence are both pinned
+- [ ] 8.4 The precedence ordering is asserted against a hostname rule and against a wildcard rule
+- [ ] 8.5 A container with several hostnames and one path produces a mounted route on each
+
+## 9. Prove it end to end
+
+- [ ] 9.1 Two containers on one hostname, one at the root and one under a path: each request reaches the right one, proved by distinct response content rather than status codes
+- [ ] 9.2 The same over HTTPS, with the same result
+- [ ] 9.3 A request for a sibling path sharing the prefix reaches the root container
+- [ ] 9.4 A wildcard container covering the same domain does not take the mounted path
+- [ ] 9.5 The mounted container stops: its paths fall through to the root container, which is the documented behaviour
+- [ ] 9.6 The root container stops: the mounted path still answers and the root does not
+- [ ] 9.7 A path on a hostname nothing else serves answers under the path and nowhere else
+- [ ] 9.8 A stack declaring no paths behaves exactly as before
+- [ ] 9.9 Test containers use an image the suite's readiness probe can actually reach, since it executes a command inside the container and the obvious image for distinguishing backends has no shell
+- [ ] 9.10 The suite's bookkeeping is updated in every place it is kept by hand: the container names, their creation and waits, the per-suite counters, the printed results block, and cleanup
+
+## 10. Ship
+
+- [ ] 10.1 Fresh-eye read of the whole diff, and a pass removing anything it does not need
+- [ ] 10.2 Pull request opened, with the automated checks green before it is merged
+- [ ] 10.3 Archive this change

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,26 @@
+schema: spec-driven
+
+context: |
+  Spark HTTP Proxy is a local development reverse proxy built on Traefik.
+
+  Three Go sidecars surround Traefik and are where most behaviour lives:
+  dinghy-layer translates VIRTUAL_HOST/VIRTUAL_PORT env vars on containers into
+  Traefik dynamic config files, join-networks connects the proxy container to
+  the networks of manageable containers, and dns-server resolves the local TLD.
+
+  Traefik runs with exposedByDefault false, so a container is only routed when
+  it opts in, either through those env vars or through native traefik.* labels.
+
+  Conventions: Go formatted with gofmt and goimports, conventional commits,
+  never push to main. Unit tests live beside the code in cmd/ and pkg/;
+  integration tests are a single shell suite under test/ that runs the real
+  stack in Docker.
+
+  This runs on every developer machine, so a regression breaks everyone's local
+  environment. Changes to routing behaviour need integration coverage, not just
+  unit tests.
+
+rules:
+  specs:
+    - Describe observable routing behaviour, never Go identifiers or Traefik
+      rule syntax. The rule strings belong in design.md.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Specification only. No behaviour changes in this pull request.

Refs #113.

## What this is

An OpenSpec change describing `VIRTUAL_PATH`, a variable that mounts a container under a path of a hostname another container already serves, so a browser-served frontend and its API can share one origin locally.

It also introduces OpenSpec in this repository. The feature touches routing precedence, path matching semantics and three test surfaces, and the reasoning behind those choices is worth recording somewhere more durable than a commit message. If you would rather not carry `openspec/` here, say so and the same content can go in `docs/` instead.

## The shape

```yaml
react:  VIRTUAL_HOST=app.loc                        VIRTUAL_PORT=5173
api:    VIRTUAL_HOST=app.loc   VIRTUAL_PATH=/api    VIRTUAL_PORT=3000
```

## Three decisions worth reviewing

**The matcher is segment-aware.** Traefik's `PathPrefix` is a raw string prefix, so `PathPrefix(`/api`)` also matches `/api-docs`. A Kubernetes Ingress `pathType: Prefix` splits on separators and does not. Since the point is that one relative call behaves the same locally and once deployed, the rule pairs them:

```
Host(`app.loc`) && (PathPrefix(`/api/`) || Path(`/api`))
```

**Priority is set on the new routes only.** Traefik orders routers by rule length when priority is unset, in one table per entrypoint, across providers. Setting a priority on the hostname routers this layer already emits would re-rank them against routers built from users' own `traefik.*` labels, and would replace today's stable exact-versus-wildcard ordering with an undefined tie. So those are left exactly as they are, and only the routes a path produces are ranked explicitly. The field also needs a non-zero floor, because a zero value with `omitempty` would be dropped and silently restore inherited ordering.

**Nothing is stripped**, matching both an Ingress and nginx-proxy's default. `VIRTUAL_DEST` is out of scope and recorded as unsupported.

## Two existing problems this surfaces

Neither is caused by the feature, both are made easier to hit by it:

- A container carrying **any** `traefik.` label is skipped whole, so its `VIRTUAL_HOST` never routes. Example 7 in `examples/applications.yml` is dead today for exactly this reason. The spec requires reporting it and fixing the example.
- `AGENTS.md` says the repository has no unit tests and that `make test` is the verification step. There are five `_test.go` files, and `make test` runs only the integration suite. Corrected as part of the work.

## Test surfaces

Three, deliberately: unit cases for parsing and rule generation, the integration suite for the routing and its failure modes, and `spark-http-proxy self-test`, so a machine where paths are broken does not report itself healthy. The diagnostic has to compare response content rather than status codes, because a missing path route falls through to the hostname's container and still answers `200`.

## Review notes

The spec went through an adversarial review that changed the priority decision, added the two silent-failure cases above, and caught that duplicate detection has to work for containers arriving as live events rather than only at startup, since developers start the proxy before their stack.

Happy to split this differently or drop the OpenSpec framing entirely if that suits the project better.


___

### **PR Type**
Documentation


___

### **Description**
- Introduce OpenSpec documentation for `VIRTUAL_PATH` routing

- Define segment-aware matching and explicit route precedence

- Specify validation, collision reporting, certificates, and tests

- Add repository-wide OpenSpec configuration and conventions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Container["Container with VIRTUAL_HOST and VIRTUAL_PATH"]
  Layer["dinghy_layer routing generation"]
  PathRouter["Segment-aware path router"]
  Backend["Container backend receives unchanged path"]
  Container -- "declares routing" --> Layer
  Layer -- "creates prioritized route" --> PathRouter
  PathRouter -- "forwards request" --> Backend
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.openspec.yaml</strong><dd><code>Register virtual path routing OpenSpec change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/virtual-path-routing/.openspec.yaml

<ul><li>Registers the <code>virtual-path-routing</code> change as spec-driven<br> <li> Records the OpenSpec change creation date</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-c2e261608c68aefeb9d8af819cc5be259c8f6f363aa7f5917c64b97625046a60">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>design.md</strong><dd><code>Document VIRTUAL_PATH routing design decisions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/virtual-path-routing/design.md

<ul><li>Documents existing routing constraints and compatibility concerns<br> <li> Explains <code>VIRTUAL_PATH</code> matching, normalization, and validation <br>decisions<br> <li> Defines explicit path-router priority without altering hostname routes<br> <li> Records trade-offs around collisions, certificates, labels, and <br>testing</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-72a31c98022e9ceb07952e02ab11c5dfeeee5cb5cbd0abf05d8b05b79243c676">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Propose shared-hostname virtual path routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/virtual-path-routing/proposal.md

<ul><li>Proposes <code>VIRTUAL_PATH</code> for shared-hostname container routing<br> <li> Summarizes segment-aware matching and path route precedence<br> <li> Identifies implementation, testing, documentation, and example impacts<br> <li> Preserves existing <code>VIRTUAL_HOST</code> and <code>VIRTUAL_PORT</code> behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-042cc414404ba46cd4a3eeca41d2079f9aa68a8383a3fc689c9890bf4d6050c2">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Specify VIRTUAL_PATH routing behavior and safeguards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/virtual-path-routing/specs/virtual-path-routing/spec.md

<ul><li>Defines observable requirements for <code>VIRTUAL_PATH</code> routing<br> <li> Specifies whole-segment matching, precedence, and unchanged backend <br>paths<br> <li> Covers malformed declarations, duplicate paths, and certificate <br>handling<br> <li> Defines diagnostic, documentation, example, and agent-skill <br>expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-d8debddc15337ee6e87dd047736b0ab70bea4217d674996a3cf030a2bb55598a">+240/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Plan VIRTUAL_PATH implementation and verification tasks</code>&nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/virtual-path-routing/tasks.md

<ul><li>Breaks implementation into parsing, routing, precedence, and reporting <br>tasks<br> <li> Lists certificate, documentation, example, and changelog follow-up <br>work<br> <li> Defines direct unit and end-to-end coverage expectations<br> <li> Tracks separate companion agent-skill release work</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-21aa0df271d982c5f2a8a03a6f6b990f16ec3853121ca7d6da4353653bfd4be9">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.yaml</strong><dd><code>Configure OpenSpec repository context and rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/config.yaml

<ul><li>Introduces repository-level OpenSpec configuration<br> <li> Describes proxy architecture, routing conventions, and test locations<br> <li> Requires observable specifications and integration coverage for <br>routing</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/114/files#diff-3463ab4be8fd566433dddf71a3b6c17f6914d9fafae4b8f8dafcf39937832af3">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra