### PR TITLE
feat(dinghy-layer): support VIRTUAL_PATH to share one hostname

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Spark HTTP Proxy is a local development reverse proxy built on Traefik. It consi
 - **`build/`** — Dockerfiles for each service (traefik, prometheus, grafana, services)
 - **`bin/compose.yml`** — Production compose (GHCR pre-built images)
 - **`compose.yml`** — Development compose (builds from source)
-- **`test/`** — Integration tests only (no unit tests exist)
+- **`test/`** — Docker-based integration tests (`test.sh`); unit tests live
+  beside the code in `cmd/` and `pkg/`
 
 ## Architecture: the big picture
 
@@ -36,10 +37,13 @@ and surround it. Understanding their interaction requires reading across `cmd/`,
    container unless explicitly opted in via `traefik.*` labels or a generated
    dynamic-config file. Ports 80/443 public, 30000→8080 dashboard.
 2. **`dinghy_layer`** (`cmd/dinghy-layer`) — the compatibility translator.
-   Watches Docker events, reads `VIRTUAL_HOST`/`VIRTUAL_PORT` env vars on
-   containers, and **writes Traefik dynamic YAML config files** into the shared
-   `traefik_dynamic` volume. This is how nginx-proxy/jwilder-style containers
-   work without native Traefik labels.
+   Watches Docker events, reads `VIRTUAL_HOST`/`VIRTUAL_PORT`/`VIRTUAL_PATH`
+   env vars on containers, and **writes Traefik dynamic YAML config files** into
+   the shared `traefik_dynamic` volume. This is how nginx-proxy/jwilder-style
+   containers work without native Traefik labels. `VIRTUAL_PATH` mounts a
+   container under a path of its `VIRTUAL_HOST`, so two containers can share one
+   domain; those routers carry an explicit `priority` while host-only routers
+   deliberately do not, keeping their existing rule-length ordering untouched.
 3. **`join_networks`** (`cmd/join-networks`) — the connectivity glue. Traefik
    can only route to containers on networks it has joined. This watches Docker
    events and **connects the `http-proxy` container to any Docker network that
@@ -83,9 +87,15 @@ are selected at runtime by their `command:` in compose.
 
 Runtime behaviour is driven by env vars (mostly `HTTP_PROXY_DNS_*` and
 `LOG_LEVEL`), defaulted in `pkg/config/config.go` and wired through
-`compose.yml`. Per-container routing is driven by `VIRTUAL_HOST`/`VIRTUAL_PORT`
-or `traefik.*` labels. When adding an env var, update `pkg/config/config.go`,
-`compose.yml`, `README.md`, and `examples/applications.yml` together.
+`compose.yml`. Per-container routing is driven by
+`VIRTUAL_HOST`/`VIRTUAL_PORT`/`VIRTUAL_PATH` or `traefik.*` labels. When adding
+an env var, update `pkg/config/config.go`, `compose.yml`, `README.md`, and
+`examples/applications.yml` together.
+
+Note that **any** `traefik.` label on a container makes `dinghy_layer` skip it
+entirely, `VIRTUAL_HOST` included. That is intentional (native labels win) but
+easy to trip over by adding a middleware label alone, so the layer now warns
+when it happens.
 
 ## Build Commands
 
@@ -107,14 +117,19 @@ rm -f cmd/dns-server/dns-server cmd/dinghy-layer/dinghy-layer cmd/join-networks/
 
 ## Test Commands
 
-There are **no unit tests**. All tests are Docker-based integration tests.
+Two suites. Unit tests sit beside the code as `_test.go` files; the integration
+suite is a single shell script that runs the real stack in Docker.
 
 ```bash
-make test                       # Full rebuild + integration tests
-./test/test.sh --no-rebuild     # Run tests against an already-running stack (faster)
+go test ./...                   # Unit tests — fast, no Docker
+make test                       # Full rebuild + integration tests (NOT unit tests)
+./test/test.sh --no-rebuild     # Run integration tests against a running stack (faster)
 ./test/test.sh --help           # Show test options
 docker compose config           # Validate compose file syntax
 ```
+
+`make test` runs the integration suite only, so run `go test ./...` as well
+before pushing. CI runs both.
 
 Tests require:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `self-test` no longer aborts on the first failed check. Its probes returned non-zero from inside a command substitution, which under `set -e` ended the script before it could report which check failed or remove the containers it had started ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - Fix the CORS example in `examples/applications.yml`, which could never have worked: its `traefik.` middleware label made the layer skip the container, so its `VIRTUAL_HOST` was ignored and no route existed. It now declares its routers as labels too ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - Correct `AGENTS.md`, which stated that the repository has no unit tests and that `make test` is the verification step. Unit tests exist beside the code, and `make test` runs only the integration suite ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - Ignore one-off containers created by `docker compose run` (labelled `com.docker.compose.oneoff=True`) in `dinghy-layer` and `join-networks`; they inherit `VIRTUAL_HOST` from the service definition and could claim the service domain with a backend port nothing listens on, returning `502` ([#111](https://github.com/sparkfabrik/http-proxy/issues/111))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support `VIRTUAL_PATH` to mount a container under a path of its `VIRTUAL_HOST`, so a browser-served frontend and its API can share one origin locally with no CORS, no preflight and one certificate. Matching is by path segment, so `/api` never captures `/api-docs`; nothing is stripped, so the backend receives the prefix it was mounted at; the mounted routers carry an explicit priority while host-only routers keep the ordering they have always had ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
+- `self-test` also checks a mounted path, over HTTP and HTTPS, comparing the response body rather than the status code: a missing path route falls through to the container serving the hostname, which answers `200` and would otherwise hide the failure ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
+- OpenSpec change tracking under `openspec/`, starting with the specification behind `VIRTUAL_PATH` ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - Add `list-certs` command to list installed certificates and `remove-cert` command to remove certificate pairs for one or more domains and restart Traefik ([#107](https://github.com/sparkfabrik/http-proxy/issues/107))
 - Unit tests for the pure parsing/config helpers in `dinghy-layer`, `dns-server`, `config`, and `utils` ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
 - CI `go-checks` job running `gofmt`, `go vet`, and `go test -race` on every non-`main` branch ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))
@@ -18,10 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Warn instead of staying silent when a container's routing variables are ignored: when it carries any `traefik.` label, which makes the layer skip it entirely, and when `VIRTUAL_PATH` is set without `VIRTUAL_HOST`. Both were debug-level, so invisible at the default log level ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
+- Warn when two containers claim the same host and path, naming both, since which of them answers is otherwise arbitrary. Detected across container events, not only at startup ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
+- `generate-mkcert` and `remove-cert` reject an argument containing a path, pointing at the hostname instead. A certificate covers a hostname, and a container mounted under a path is served by its host's certificate ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - `self-test` now verifies end-to-end routing instead of only DNS liveness: it starts a throwaway container with `VIRTUAL_HOST`, asserts DNS resolves the test domain to the configured target IP, and that the proxy serves it over both HTTP and HTTPS (with retries while routes propagate), then cleans up. Exits non-zero with a per-check report on failure ([#104](https://github.com/sparkfabrik/http-proxy/issues/104))
 
 ### Fixed
 
+- Fix the CORS example in `examples/applications.yml`, which could never have worked: its `traefik.` middleware label made the layer skip the container, so its `VIRTUAL_HOST` was ignored and no route existed. It now declares its routers as labels too ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
+- Correct `AGENTS.md`, which stated that the repository has no unit tests and that `make test` is the verification step. Unit tests exist beside the code, and `make test` runs only the integration suite ([#113](https://github.com/sparkfabrik/http-proxy/issues/113))
 - Ignore one-off containers created by `docker compose run` (labelled `com.docker.compose.oneoff=True`) in `dinghy-layer` and `join-networks`; they inherit `VIRTUAL_HOST` from the service definition and could claim the service domain with a backend port nothing listens on, returning `502` ([#111](https://github.com/sparkfabrik/http-proxy/issues/111))
 - Reconcile the generated `dinghy-layer` config files against running containers during the initial scan, removing orphaned files whose container no longer exists; a recreated container previously kept a stale backend IP that returned `502` until a full teardown ([#109](https://github.com/sparkfabrik/http-proxy/issues/109))
 - Make backend IP and port selection deterministic for `VIRTUAL_HOST` containers attached to multiple networks or exposing multiple ports; previously Go map iteration could route to a different network IP or port across restarts ([#101](https://github.com/sparkfabrik/http-proxy/issues/101))

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Simply add `VIRTUAL_HOST=myapp.local` to any container or use native Traefik lab
   - [Optional Commands](#optional-commands)
 - [Container Configuration](#container-configuration)
   - [Supported Patterns](#supported-patterns)
+  - [Sharing one domain with VIRTUAL_PATH](#sharing-one-domain-with-virtual_path)
 - [Container Management](#container-management)
 - [Network Management](#network-management)
 - [DNS Server](#dns-server)
@@ -48,6 +49,7 @@ Simply add `VIRTUAL_HOST=myapp.local` to any container or use native Traefik lab
   - [Using Traefik Labels Instead of VIRTUAL_HOST](#using-traefik-labels-instead-of-virtual_host)
 - [Dinghy Layer Compatibility](#dinghy-layer-compatibility)
   - [Supported Environment Variables](#supported-environment-variables)
+  - [Borrowed from nginx-proxy](#borrowed-from-nginx-proxy)
   - [Migration Notes](#migration-notes)
 - [DNS Server](#dns-server-1)
   - [DNS Configuration](#dns-configuration-1)
@@ -145,16 +147,71 @@ services:
     environment:
       - VIRTUAL_HOST=myapp.local # Required: your custom domain
       - VIRTUAL_PORT=8080 # Optional: defaults to exposed port or 80
+      - VIRTUAL_PATH=/api # Optional: mount under a path of VIRTUAL_HOST
     expose:
       - "8080"
 ```
 
 ### Supported Patterns
 
+`VIRTUAL_HOST` accepts several forms:
+
 - **Single domain**: `VIRTUAL_HOST=myapp.local`
 - **Multiple domains**: `VIRTUAL_HOST=app.local,api.local`
 - **Wildcards**: `VIRTUAL_HOST=*.myapp.local`
 - **Regex patterns**: `VIRTUAL_HOST=~^api\\..*\\.local$`
+
+`VIRTUAL_PATH` is a separate variable, not another host form. It mounts the
+container under a path of the hostname `VIRTUAL_HOST` names, so two containers
+can share one domain.
+
+### Sharing one domain with VIRTUAL_PATH
+
+A browser-served frontend and its API often need to be on one origin: same
+domain, so no CORS, no preflight, and one certificate. Point both containers at
+the same `VIRTUAL_HOST` and give the second a `VIRTUAL_PATH`:
+
+```yaml
+# docker-compose.yml
+services:
+  frontend:
+    image: node:22-alpine
+    environment:
+      - VIRTUAL_HOST=myapp.local
+      - VIRTUAL_PORT=5173
+
+  api:
+    image: node:22-alpine
+    environment:
+      - VIRTUAL_HOST=myapp.local # the same domain
+      - VIRTUAL_PATH=/api # mounted under it
+      - VIRTUAL_PORT=3000
+```
+
+`http://myapp.local/` reaches the frontend and `http://myapp.local/api/...`
+reaches the API, so the page can call `/api/...` with no host in front of it.
+
+What to know before using it:
+
+- **`/api` matches `/api` and everything under it, never `/api-docs`.** Matching
+  is by path segment, so a mount cannot capture a sibling that merely starts
+  with the same characters.
+- **Nothing is stripped.** The API receives `/api/users`, not `/users`, so it
+  has to serve the prefix itself. `VIRTUAL_DEST` is not supported.
+- **A certificate covers the hostname**, so a mounted path needs none of its
+  own and is served by the certificate of the domain it sits on.
+- **`VIRTUAL_PORT` belongs to the container.** Each container has its own,
+  independently of the others sharing the domain.
+- **`VIRTUAL_PATH` applies to every domain the container names.** With
+  `VIRTUAL_HOST=a.local,b.local` the container is mounted at that path on both.
+- **A `traefik.*` label disables both variables.** A container carrying any
+  `traefik.` label is handled by Traefik's Docker provider instead, so its
+  `VIRTUAL_HOST` and `VIRTUAL_PATH` are ignored entirely.
+- **Stopping the mounted container does not produce a 404.** Its routes go with
+  it and its paths fall through to whichever container serves the domain, which
+  for a dev server usually means a page and a `200`.
+- **Changing the value needs the container recreated**, since environment
+  variables cannot be changed in place.
 
 ## Container Management
 
@@ -563,6 +620,20 @@ This HTTP proxy provides compatibility with the original [dinghy-http-proxy](htt
 | -------------- | ----------- | -------------------------------- |
 | `VIRTUAL_HOST` | ✅ **Full** | Automatic HTTP and HTTPS routing |
 | `VIRTUAL_PORT` | ✅ **Full** | Backend port configuration       |
+
+### Borrowed from nginx-proxy
+
+`VIRTUAL_PATH` is not a dinghy-http-proxy variable. It comes from
+[nginx-proxy](https://github.com/nginx-proxy/nginx-proxy), which uses it for the
+same purpose:
+
+| Variable       | Support         | Description                                              |
+| -------------- | --------------- | -------------------------------------------------------- |
+| `VIRTUAL_PATH` | ✅ **Full**     | Mount a container under a path of its `VIRTUAL_HOST`      |
+| `VIRTUAL_DEST` | ❌ **None**     | Rewriting the path before the backend sees it             |
+
+Without `VIRTUAL_DEST` the request reaches the backend unchanged, which matches
+both nginx-proxy's own default and how an ingress forwards a path prefix.
 
 ### Migration Notes
 

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -446,6 +446,10 @@ generate_mkcert() {
     exit 1
   fi
 
+  if ! reject_path_in_domain "${domain}"; then
+    exit 1
+  fi
+
   if ! install_mkcert; then
     exit 1
   fi
@@ -468,6 +472,24 @@ generate_mkcert() {
   # Restart traefik to apply new certificates.
   log_info "Restarting Traefik to apply new certificates..."
   docker compose -f "${COMPOSE_FILE}" restart traefik
+}
+
+# Reject a certificate argument that names a path rather than a hostname.
+# A certificate covers a hostname, and a container mounted under a path with
+# VIRTUAL_PATH is served by the certificate of the host it sits on. Without this
+# check the path would be folded into the filename and the request would half
+# succeed, leaving a certificate nothing can use.
+reject_path_in_domain() {
+  local domain="$1"
+
+  if [[ "${domain}" == */* ]]; then
+    log_error "'${domain}' contains a path. A certificate covers a hostname."
+    log_info "Use the hostname on its own: ${domain%%/*}"
+    log_info "A container mounted with VIRTUAL_PATH is served by its host's certificate."
+    return 1
+  fi
+
+  return 0
 }
 
 # Derive the safe filename used to store a domain's certificate files
@@ -539,6 +561,9 @@ remove_cert() {
   local -a missing=()
   local domain safe_filename cert_file key_file
   for domain in "$@"; do
+    if ! reject_path_in_domain "${domain}"; then
+      exit 1
+    fi
     safe_filename="$(cert_safe_filename "${domain}")"
     cert_file="${CERT_DIR}/${safe_filename}.pem"
     key_file="${CERT_DIR}/${safe_filename}-key.pem"
@@ -623,13 +648,13 @@ is_running() { dc_cmd ps | grep -q "$1"; }
 # Uses --resolve so both the connection target and the TLS SNI match the test
 # host, exercising the real routing path. Echoes the last status code seen.
 self_test_http_probe() {
-  local scheme="$1" host="$2" port="$3" extra="$4"
+  local scheme="$1" host="$2" port="$3" extra="$4" path="${5:-}"
   local code=""
 
   for _ in $(seq 1 15); do
     code="$(curl ${extra} -s -o /dev/null -w '%{http_code}' \
       --resolve "${host}:${port}:127.0.0.1" --max-time 5 \
-      "${scheme}://${host}" 2>/dev/null || true)"
+      "${scheme}://${host}${path}" 2>/dev/null || true)"
     if [[ "${code}" == "200" ]]; then
       echo "200"
       return 0
@@ -641,15 +666,44 @@ self_test_http_probe() {
   return 1
 }
 
+# Poll a URL until it returns the expected body, or attempts run out.
+#
+# A mounted path cannot be checked by status code alone. When its route is
+# missing, the request falls through to whatever serves the hostname, which
+# answers 200 from the wrong container, so a status probe passes on a machine
+# where VIRTUAL_PATH is broken. Comparing the body is what makes the check
+# meaningful. Echoes the last body seen.
+self_test_body_probe() {
+  local scheme="$1" host="$2" port="$3" extra="$4" path="$5" expected="$6"
+  local body=""
+
+  for _ in $(seq 1 15); do
+    body="$(curl ${extra} -s \
+      --resolve "${host}:${port}:127.0.0.1" --max-time 5 \
+      "${scheme}://${host}${path}" 2>/dev/null || true)"
+    if [[ "${body}" == *"${expected}"* ]]; then
+      echo "${expected}"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "${body}"
+  return 1
+}
+
 # Self-test: end-to-end check that the proxy actually routes a container.
 run_self_test() {
   local first_tld test_domain container_name dns_port target_ip
   local resolved http_code https_code failures=0
+  local path_container_name path_body https_path_body
+  local path_marker="spark-http-proxy path routing works"
 
   first_tld="${HTTP_PROXY_DNS_TLDS:-loc}"
   first_tld="$(echo "${first_tld%%,*}" | tr -d '[:space:]')"
   test_domain="spark-http-proxy-selftest.${first_tld}"
   container_name="spark-proxy-self-test"
+  path_container_name="spark-proxy-self-test-path"
   dns_port="${HTTP_PROXY_DNS_PORT:-19322}"
   target_ip="${HTTP_PROXY_DNS_TARGET_IP:-127.0.0.1}"
 
@@ -666,14 +720,27 @@ run_self_test() {
   fi
   log_success "Proxy and DNS services are running"
 
-  # Always remove the test container when the function returns
-  trap 'docker rm -f "'"${container_name}"'" >/dev/null 2>&1 || true' RETURN
+  # Always remove the test containers when the function returns
+  trap 'docker rm -f "'"${container_name}"'" "'"${path_container_name}"'" >/dev/null 2>&1 || true' RETURN
 
   # 2. Start a throwaway backend opted into the proxy via VIRTUAL_HOST
   log_info "Starting test container with VIRTUAL_HOST=${test_domain}..."
   docker rm -f "${container_name}" >/dev/null 2>&1 || true
   if ! docker run -d --name "${container_name}" -e "VIRTUAL_HOST=${test_domain}" nginx:latest >/dev/null 2>&1; then
     log_error "Failed to start test container"
+    return 1
+  fi
+
+  # A second backend on the same hostname, mounted under a path. It serves a
+  # marker the host's container does not, which is what distinguishes a working
+  # path route from a request falling through to the host.
+  log_info "Starting test container with VIRTUAL_PATH=/self-test on the same host..."
+  docker rm -f "${path_container_name}" >/dev/null 2>&1 || true
+  if ! docker run -d --name "${path_container_name}" \
+    -e "VIRTUAL_HOST=${test_domain}" -e "VIRTUAL_PATH=/self-test" \
+    -e "MARKER=${path_marker}" \
+    nginx:latest sh -c 'mkdir -p /usr/share/nginx/html/self-test && printf "%s" "${MARKER}" > /usr/share/nginx/html/self-test/index.html && exec nginx -g "daemon off;"' >/dev/null 2>&1; then
+    log_error "Failed to start path test container"
     return 1
   fi
 
@@ -704,6 +771,28 @@ run_self_test() {
     log_success "HTTPS route works (200)"
   else
     log_error "HTTPS route failed (last status: ${https_code:-none})"
+    failures=$((failures + 1))
+  fi
+
+  # 6. A container mounted under a path must answer that path itself. Checked by
+  # body, not status: without the path route the request reaches the host's
+  # container, which answers 200 and would hide the failure.
+  log_info "Testing VIRTUAL_PATH routing..."
+  path_body="$(self_test_body_probe http "${test_domain}" 80 "" "/self-test" "${path_marker}")"
+  if [[ "${path_body}" == "${path_marker}" ]]; then
+    log_success "Path route works (/self-test answered by the mounted container)"
+  else
+    log_error "Path route failed (/self-test was not answered by the mounted container)"
+    failures=$((failures + 1))
+  fi
+
+  # 7. The same over HTTPS, so the two schemes cannot diverge unnoticed
+  log_info "Testing VIRTUAL_PATH routing over HTTPS..."
+  https_path_body="$(self_test_body_probe https "${test_domain}" 443 "-k" "/self-test" "${path_marker}")"
+  if [[ "${https_path_body}" == "${path_marker}" ]]; then
+    log_success "Path route works over HTTPS"
+  else
+    log_error "Path route over HTTPS failed"
     failures=$((failures + 1))
   fi
 

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -662,8 +662,10 @@ self_test_http_probe() {
     sleep 2
   done
 
+  # Always succeeds, for the same reason as the body probe below: a non-zero
+  # return inside the caller's command substitution would abort the self-test
+  # under set -e instead of letting it report which check failed.
   echo "${code}"
-  return 1
 }
 
 # Poll a URL until it returns the expected body, or attempts run out.
@@ -678,7 +680,10 @@ self_test_body_probe() {
   local body=""
 
   for _ in $(seq 1 15); do
-    body="$(curl ${extra} -s \
+    # -L because a backend serving a directory answers the bare path with a
+    # redirect to the trailing-slash form, and that redirect page looks the
+    # same whichever container produced it.
+    body="$(curl ${extra} -s -L \
       --resolve "${host}:${port}:127.0.0.1" --max-time 5 \
       "${scheme}://${host}${path}" 2>/dev/null || true)"
     if [[ "${body}" == *"${expected}"* ]]; then
@@ -688,8 +693,10 @@ self_test_body_probe() {
     sleep 2
   done
 
+  # Always succeeds: the caller assigns this in a command substitution, and
+  # under set -e a non-zero return there would abort the whole self-test before
+  # it could report the failure or clean up its containers.
   echo "${body}"
-  return 1
 }
 
 # Self-test: end-to-end check that the proxy actually routes a container.

--- a/bin/spark-http-proxy
+++ b/bin/spark-http-proxy
@@ -795,7 +795,7 @@ run_self_test() {
 
   # 7. The same over HTTPS, so the two schemes cannot diverge unnoticed
   log_info "Testing VIRTUAL_PATH routing over HTTPS..."
-  https_path_body="$(self_test_body_probe https "${test_domain}" 443 "-k" "/self-test" "${path_marker}")"
+  https_path_body="$(self_test_body_probe https "${test_domain}" 443 "-k" "/self-test/" "${path_marker}")"
   if [[ "${https_path_body}" == "${path_marker}" ]]; then
     log_success "Path route works over HTTPS"
   else

--- a/cmd/dinghy-layer/main.go
+++ b/cmd/dinghy-layer/main.go
@@ -44,6 +44,28 @@ type CompatibilityLayer struct {
 	dockerClient *client.Client
 	logger       *logger.Logger
 	config       *CompatibilityConfig
+
+	// claims records which container holds each host-and-path pair, so a second
+	// container claiming one already taken can be reported. Detecting this only
+	// during the initial scan would miss the ordinary case, where the proxy is
+	// already running and a compose stack starts afterwards, so both containers
+	// arrive as separate events.
+	claims map[routeClaim]claimHolder
+}
+
+// routeClaim identifies a route by what a request has to match to reach it.
+// The empty path is the host's own route, so two containers claiming a bare
+// host collide on the same key as two claiming the same path.
+type routeClaim struct {
+	host string
+	path string
+}
+
+// claimHolder is the container holding a claim. The ID is the identity, since
+// a container is recreated with the same name; the name is what a reader needs.
+type claimHolder struct {
+	id   string
+	name string
 }
 
 // CompatibilityConfig holds the configuration options for the compatibility layer.
@@ -69,6 +91,7 @@ func (c *CompatibilityConfig) Validate() error {
 func NewCompatibilityLayer(cfg *CompatibilityConfig) *CompatibilityLayer {
 	return &CompatibilityLayer{
 		config: cfg,
+		claims: make(map[routeClaim]claimHolder),
 	}
 }
 
@@ -91,6 +114,7 @@ type ContainerInfo struct {
 	Name        string
 	VirtualHost string
 	VirtualPort string
+	VirtualPath string
 	IsRunning   bool
 }
 
@@ -101,6 +125,7 @@ func (cl *CompatibilityLayer) extractContainerInfo(inspect types.ContainerJSON) 
 		Name:        strings.TrimPrefix(inspect.Name, "/"),
 		VirtualHost: utils.GetDockerEnvVar(inspect.Config.Env, "VIRTUAL_HOST"),
 		VirtualPort: utils.GetDockerEnvVar(inspect.Config.Env, "VIRTUAL_PORT"),
+		VirtualPath: utils.GetDockerEnvVar(inspect.Config.Env, "VIRTUAL_PATH"),
 		IsRunning:   inspect.State.Running,
 	}
 }
@@ -221,8 +246,18 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 		return "", nil
 	}
 
-	// Skip if no VIRTUAL_HOST found
+	// Skip if no VIRTUAL_HOST found. A container asking for a path without a
+	// host is a mistake rather than a container that opted out, so it is worth
+	// saying out loud: a path needs a hostname to sit on, and without
+	// VIRTUAL_HOST nothing exposes the container at all.
 	if containerInfo.VirtualHost == "" {
+		if containerInfo.VirtualPath != "" {
+			cl.logger.Warn("Ignoring VIRTUAL_PATH on a container without VIRTUAL_HOST",
+				"container_id", utils.FormatDockerID(containerID),
+				"container_name", containerInfo.Name,
+				"virtual_path", containerInfo.VirtualPath)
+			return "", nil
+		}
 		cl.logger.Debug("Skipping container without VIRTUAL_HOST",
 			"container_id", utils.FormatDockerID(containerID),
 			"container_name", containerInfo.Name)
@@ -241,8 +276,21 @@ func (cl *CompatibilityLayer) processContainer(ctx context.Context, containerID 
 	}
 
 	// Skip if traefik labels are already set; native labels take precedence and
-	// Traefik's Docker provider handles those containers directly.
+	// Traefik's Docker provider handles those containers directly. Any
+	// traefik. label counts, including a middleware that was never meant to
+	// take over routing, so a container that also declares VIRTUAL_HOST loses
+	// it. That is easy to hit when reaching for a middleware alongside a
+	// mounted path, and silent at debug level, so say it plainly instead.
 	if utils.HasTraefikLabel(inspect.Config.Labels) {
+		if containerInfo.VirtualHost != "" {
+			cl.logger.Warn("Ignoring VIRTUAL_HOST and VIRTUAL_PATH on a container carrying a traefik. label",
+				"container_id", utils.FormatDockerID(containerID),
+				"container_name", containerInfo.Name,
+				"virtual_host", containerInfo.VirtualHost,
+				"virtual_path", containerInfo.VirtualPath,
+				"hint", "declare the routers as labels too, or remove the label")
+			return "", nil
+		}
 		cl.logger.Debug("Skipping container with existing Traefik label",
 			"container_id", utils.FormatDockerID(containerID),
 			"container_name", containerInfo.Name)
@@ -280,12 +328,29 @@ func (cl *CompatibilityLayer) generateTraefikConfig(inspect types.ContainerJSON,
 	// Parse VIRTUAL_HOST (can contain multiple hosts separated by commas)
 	hosts := parseVirtualHosts(containerInfo.VirtualHost)
 
+	// VIRTUAL_PATH belongs to the container, not to an individual host entry,
+	// so a container naming several hosts is mounted at the same path on each.
+	// An unusable value is reported and dropped: the container still gets its
+	// host routes rather than disappearing from the proxy entirely.
+	virtualPath, err := normalizeVirtualPath(containerInfo.VirtualPath)
+	if err != nil {
+		cl.logger.Warn("Ignoring VIRTUAL_PATH",
+			"container_id", utils.FormatDockerID(inspect.ID),
+			"container_name", containerInfo.Name,
+			"virtual_path", containerInfo.VirtualPath,
+			"reason", err)
+	}
+
 	// Get container IP address
 	containerIP := getContainerIP(inspect)
 	if containerIP == "" {
 		cl.logger.Error("Could not determine container IP", "container_id", utils.FormatDockerID(inspect.ID))
 		return traefikConfig
 	}
+
+	// Recorded only once the container can actually be routed to, so one with
+	// no address does not hold a route it cannot serve.
+	cl.recordClaims(containerInfo, hosts, virtualPath)
 
 	for i, host := range hosts {
 		routerName := fmt.Sprintf("%s-%d", serviceName, i)
@@ -307,10 +372,20 @@ func (cl *CompatibilityLayer) generateTraefikConfig(inspect types.ContainerJSON,
 			rule = fmt.Sprintf("Host(`%s`)", host.hostname)
 		}
 
+		// A mounted path narrows the rule and takes an explicit priority. Host
+		// routers keep taking Traefik's rule-length ordering, so containers
+		// that do not use VIRTUAL_PATH rank exactly as they always have.
+		priority := 0
+		if virtualPath != "" {
+			rule = fmt.Sprintf("%s && %s", rule, pathMatcher(virtualPath))
+			priority = pathPriority(virtualPath)
+		}
+
 		// Create HTTP router
 		httpRouter := &config.Router{
 			Rule:        rule,
 			Service:     serviceName,
+			Priority:    priority,
 			EntryPoints: []string{"http"},
 		}
 		traefikConfig.HTTP.Routers[routerName] = httpRouter
@@ -320,6 +395,7 @@ func (cl *CompatibilityLayer) generateTraefikConfig(inspect types.ContainerJSON,
 		httpsRouter := &config.Router{
 			Rule:        rule,
 			Service:     serviceName,
+			Priority:    priority,
 			EntryPoints: []string{"https"},
 			TLS:         &config.RouterTLSConfig{},
 		}
@@ -424,6 +500,10 @@ func (cl *CompatibilityLayer) writeTraefikConfig(containerID string, cfg *config
 }
 
 func (cl *CompatibilityLayer) removeTraefikConfig(containerID string) error {
+	// Free the routes first, so a replacement container taking the same host
+	// and path is not reported as colliding with the one it replaced.
+	cl.releaseClaims(containerID)
+
 	if cl.config.DryRun {
 		cl.logger.Info("DRY RUN: Would remove Traefik config",
 			"container_id", utils.FormatDockerID(containerID),
@@ -532,6 +612,115 @@ func parseVirtualHosts(virtualHostEnv string) []virtualHost {
 	}
 
 	return hosts
+}
+
+// pathPriorityBase lifts every mounted-path router above the rule-length
+// ordering Traefik applies when no priority is set. Rule length is bounded by
+// how long a hostname and a path can plausibly be, so a base well past that
+// keeps a mounted path ahead of a bare host and of a wildcard that happens to
+// produce a long regex.
+const pathPriorityBase = 10000
+
+// normalizeVirtualPath validates VIRTUAL_PATH and returns the form used to
+// build a rule: a leading separator, no trailing one, and empty when the
+// container is not mounted under a path at all.
+//
+// The empty return with a non-nil error is deliberate. A container whose path
+// cannot be used still deserves its host routes, so callers report the error
+// and carry on with the empty value.
+func normalizeVirtualPath(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", nil
+	}
+
+	// A list is the mistake VIRTUAL_HOST's own syntax invites. Commas are legal
+	// in a URL path, so accepting one would build a rule that never matches.
+	if strings.Contains(path, ",") {
+		return "", fmt.Errorf("must be a single path, not a list")
+	}
+
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("must start with /")
+	}
+
+	// The rule is assembled by string formatting, so a backtick would close the
+	// matcher and let the rest of the value become routing syntax. The other
+	// characters here cannot appear in a path Traefik matches against.
+	if strings.ContainsAny(path, "`$\"'\\ \t\n\r?#") {
+		return "", fmt.Errorf("contains characters that are not allowed in a path")
+	}
+
+	// Trailing separators are stripped so /api and /api/ are one declaration.
+	// Repeated separators would produce a path no request can match.
+	trimmed := strings.TrimRight(path, "/")
+	if trimmed == "" {
+		// VIRTUAL_PATH=/ addresses the whole host, which VIRTUAL_HOST already
+		// does. Treated as absent rather than as a second route for the host.
+		return "", nil
+	}
+	if strings.Contains(trimmed, "//") {
+		return "", fmt.Errorf("contains an empty path segment")
+	}
+
+	return trimmed, nil
+}
+
+// pathMatcher builds the matcher for a mounted path.
+//
+// PathPrefix alone is a raw string prefix in Traefik, so PathPrefix(`/api`)
+// also matches /api-docs. An Ingress path prefix splits on separators and does
+// not, and the point of mounting a path locally is that one relative call
+// behaves the same in both places. Pairing the prefix with an exact match
+// restores segment-aware behaviour.
+func pathMatcher(path string) string {
+	return fmt.Sprintf("(PathPrefix(`%s/`) || Path(`%s`))", path, path)
+}
+
+// pathPriority ranks a mounted path above the host it sits on, and a longer
+// path above a shorter one on the same host, so /api/internal wins over /api.
+func pathPriority(path string) int {
+	return pathPriorityBase + len(path)
+}
+
+// recordClaims registers the routes a container is about to be given and
+// reports any that another container already holds. Which of the two answers
+// such a request is decided by Traefik's own ordering of identical rules, so
+// the only useful thing to do is name both and let a human resolve it.
+func (cl *CompatibilityLayer) recordClaims(info ContainerInfo, hosts []virtualHost, path string) {
+	cl.releaseClaims(info.ID)
+
+	for _, host := range hosts {
+		claim := routeClaim{host: host.hostname, path: path}
+		if holder, taken := cl.claims[claim]; taken && holder.id != info.ID {
+			cl.logger.Warn("Two containers claim the same route",
+				"host", claim.host,
+				"path", claimPathForLog(claim.path),
+				"containers", fmt.Sprintf("%s, %s", holder.name, info.Name),
+				"hint", "which one answers is not defined; give one of them a different host or path")
+			continue
+		}
+		cl.claims[claim] = claimHolder{id: info.ID, name: info.Name}
+	}
+}
+
+// releaseClaims drops everything a container holds, so a route freed by one
+// container stopping can be taken by another without a false collision.
+func (cl *CompatibilityLayer) releaseClaims(containerID string) {
+	for claim, holder := range cl.claims {
+		if holder.id == containerID {
+			delete(cl.claims, claim)
+		}
+	}
+}
+
+// claimPathForLog renders the host's own route, which has no path, as something
+// readable rather than as an empty value.
+func claimPathForLog(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
 }
 
 func isPort(s string) bool {

--- a/cmd/dinghy-layer/main_test.go
+++ b/cmd/dinghy-layer/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -10,12 +12,14 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/sparkfabrik/http-proxy/pkg/logger"
+	"gopkg.in/yaml.v3"
 )
 
 func testLayer() *CompatibilityLayer {
 	return &CompatibilityLayer{
 		logger: logger.New("test"),
 		config: &CompatibilityConfig{TraefikDynamicDir: "/tmp"},
+		claims: make(map[routeClaim]claimHolder),
 	}
 }
 
@@ -417,5 +421,264 @@ func TestGenerateTraefikConfigMultiHost(t *testing.T) {
 	}
 	if got := len(cfg.HTTP.Services); got != 1 {
 		t.Errorf("service count = %d, want 1", got)
+	}
+}
+
+func TestNormalizeVirtualPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"absent", "", "", false},
+		{"simple", "/api", "/api", false},
+		{"trailing separator is stripped", "/api/", "/api", false},
+		{"nested", "/api/v1", "/api/v1", false},
+		{"surrounding space is ignored", "  /api  ", "/api", false},
+		{"root is the host itself", "/", "", false},
+		{"repeated separators only", "///", "", false},
+		{"no leading separator", "api", "", true},
+		{"a list is not a path", "/api,/admin", "", true},
+		{"query string", "/api?x=1", "", true},
+		{"fragment", "/api#top", "", true},
+		{"embedded space", "/api v1", "", true},
+		{"empty segment", "/api//v1", "", true},
+		{"backtick closes the matcher", "/api`) || Host(`evil.loc", "", true},
+		{"double quote", "/api\"", "", true},
+		{"single quote", "/api'", "", true},
+		{"backslash", "/api\\x", "", true},
+		{"dollar", "/api$x", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeVirtualPath(tt.input)
+			if tt.wantErr && err == nil {
+				t.Fatalf("normalizeVirtualPath(%q) = %q, want an error", tt.input, got)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("normalizeVirtualPath(%q) returned %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizeVirtualPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// A rejected path must not take the container's host routes down with it.
+func TestGenerateTraefikConfigRejectedPathKeepsHostRoutes(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/bad", "172.0.0.9")
+	info := ContainerInfo{Name: "bad", VirtualHost: "bad.loc", VirtualPort: "80", VirtualPath: "api"}
+
+	cfg := cl.generateTraefikConfig(inspect, info)
+
+	router, ok := cfg.HTTP.Routers["bad-0"]
+	if !ok {
+		t.Fatalf("missing router bad-0; got %v", cfg.HTTP.Routers)
+	}
+	if router.Rule != "Host(`bad.loc`)" {
+		t.Errorf("rule = %q, want the plain host rule", router.Rule)
+	}
+	if router.Priority != 0 {
+		t.Errorf("priority = %d, want 0 for a container with no usable path", router.Priority)
+	}
+}
+
+func TestGenerateTraefikConfigMountedPath(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/api", "172.0.0.7")
+	info := ContainerInfo{Name: "api", VirtualHost: "app.loc", VirtualPort: "3000", VirtualPath: "/api"}
+
+	cfg := cl.generateTraefikConfig(inspect, info)
+
+	wantRule := "Host(`app.loc`) && (PathPrefix(`/api/`) || Path(`/api`))"
+	wantPriority := pathPriorityBase + len("/api")
+
+	for _, name := range []string{"api-0", "api-tls-0"} {
+		router, ok := cfg.HTTP.Routers[name]
+		if !ok {
+			t.Fatalf("missing router %s; got %v", name, cfg.HTTP.Routers)
+		}
+		if router.Rule != wantRule {
+			t.Errorf("%s rule = %q, want %q", name, router.Rule, wantRule)
+		}
+		// Both schemes must rank together, or a request could reach different
+		// containers over http and https.
+		if router.Priority != wantPriority {
+			t.Errorf("%s priority = %d, want %d", name, router.Priority, wantPriority)
+		}
+	}
+}
+
+// A container without VIRTUAL_PATH must emit no priority at all, so its
+// ordering against every other router on the machine is the one it always had.
+func TestGenerateTraefikConfigHostOnlyEmitsNoPriority(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/plain", "172.0.0.8")
+	info := ContainerInfo{Name: "plain", VirtualHost: "plain.loc", VirtualPort: "80"}
+
+	cfg := cl.generateTraefikConfig(inspect, info)
+
+	for name, router := range cfg.HTTP.Routers {
+		if router.Priority != 0 {
+			t.Errorf("%s priority = %d, want 0", name, router.Priority)
+		}
+	}
+
+	// The zero must also disappear from the emitted YAML. Traefik reads a
+	// missing priority as "rank by rule length"; a literal 0 would mean the
+	// same thing, but the field is only ever meaningful when it is non-zero,
+	// and serialising it would misrepresent an untouched router as configured.
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "priority") {
+		t.Errorf("host-only config mentions priority:\n%s", out)
+	}
+}
+
+// The priority has to survive marshalling: with omitempty a zero would vanish
+// and silently restore rule-length ordering.
+func TestMountedPathPriorityIsSerialised(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/api", "172.0.0.7")
+	info := ContainerInfo{Name: "api", VirtualHost: "app.loc", VirtualPort: "3000", VirtualPath: "/api"}
+
+	out, err := yaml.Marshal(cl.generateTraefikConfig(inspect, info))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := fmt.Sprintf("priority: %d", pathPriorityBase+len("/api"))
+	if !strings.Contains(string(out), want) {
+		t.Errorf("emitted config is missing %q:\n%s", want, out)
+	}
+}
+
+// The ordering the feature depends on: a mounted path must outrank the host it
+// sits on and any wildcard covering that host, and a longer path must outrank a
+// shorter one. Host rules carry no priority, so Traefik ranks them by rule
+// length, which is bounded well below the base.
+func TestPathPriorityOrdering(t *testing.T) {
+	host := len("Host(`app.loc`)")
+	wildcard := len("HostRegexp(`^.*\\.a\\.very\\.long\\.example\\.domain\\.loc$`)")
+
+	short := pathPriority("/api")
+	long := pathPriority("/api/internal")
+
+	if short <= host {
+		t.Errorf("mounted path priority %d does not outrank the host rule length %d", short, host)
+	}
+	if short <= wildcard {
+		t.Errorf("mounted path priority %d does not outrank the wildcard rule length %d", short, wildcard)
+	}
+	if long <= short {
+		t.Errorf("longer path priority %d does not outrank shorter path priority %d", long, short)
+	}
+}
+
+// VIRTUAL_PATH belongs to the container, so every host it names is mounted.
+func TestGenerateTraefikConfigMountedPathAcrossHosts(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/api", "172.0.0.10")
+	info := ContainerInfo{Name: "api", VirtualHost: "a.loc,b.loc", VirtualPort: "3000", VirtualPath: "/api"}
+
+	cfg := cl.generateTraefikConfig(inspect, info)
+
+	if got := len(cfg.HTTP.Routers); got != 4 {
+		t.Fatalf("router count = %d, want 4", got)
+	}
+	for i, host := range []string{"a.loc", "b.loc"} {
+		name := fmt.Sprintf("api-%d", i)
+		router, ok := cfg.HTTP.Routers[name]
+		if !ok {
+			t.Fatalf("missing router %s; got %v", name, cfg.HTTP.Routers)
+		}
+		want := fmt.Sprintf("Host(`%s`) && (PathPrefix(`/api/`) || Path(`/api`))", host)
+		if router.Rule != want {
+			t.Errorf("%s rule = %q, want %q", name, router.Rule, want)
+		}
+	}
+}
+
+// A wildcard host keeps its meaning when a path is mounted on it.
+func TestGenerateTraefikConfigMountedPathOnWildcard(t *testing.T) {
+	cl := testLayer()
+	inspect := inspectWithIP("/api", "172.0.0.11")
+	info := ContainerInfo{Name: "api", VirtualHost: "*.app.loc", VirtualPort: "3000", VirtualPath: "/api"}
+
+	cfg := cl.generateTraefikConfig(inspect, info)
+
+	router, ok := cfg.HTTP.Routers["api-0"]
+	if !ok {
+		t.Fatalf("missing router api-0; got %v", cfg.HTTP.Routers)
+	}
+	if !strings.HasPrefix(router.Rule, "HostRegexp(`") {
+		t.Errorf("rule = %q, want a HostRegexp matcher", router.Rule)
+	}
+	if !strings.HasSuffix(router.Rule, "&& (PathPrefix(`/api/`) || Path(`/api`))") {
+		t.Errorf("rule = %q, want the path matcher appended", router.Rule)
+	}
+}
+
+func TestRecordClaimsDetectsDuplicates(t *testing.T) {
+	cl := testLayer()
+	hosts := []virtualHost{{hostname: "app.loc"}}
+
+	first := ContainerInfo{ID: "aaa", Name: "first"}
+	second := ContainerInfo{ID: "bbb", Name: "second"}
+
+	cl.recordClaims(first, hosts, "/api")
+	if got := cl.claims[routeClaim{host: "app.loc", path: "/api"}].name; got != "first" {
+		t.Fatalf("claim holder = %q, want first", got)
+	}
+
+	// The second container must not take the claim from the first: reporting
+	// the collision is the point, and the holder is what the report names.
+	cl.recordClaims(second, hosts, "/api")
+	if got := cl.claims[routeClaim{host: "app.loc", path: "/api"}].name; got != "first" {
+		t.Errorf("claim holder = %q, want it to stay with first", got)
+	}
+
+	// A different path on the same host is not a collision.
+	cl.recordClaims(second, hosts, "/admin")
+	if got := cl.claims[routeClaim{host: "app.loc", path: "/admin"}].name; got != "second" {
+		t.Errorf("claim holder for /admin = %q, want second", got)
+	}
+}
+
+// A container replacing another on the same route must not report a collision
+// against the container it replaced.
+func TestReleaseClaimsFreesTheRoute(t *testing.T) {
+	cl := testLayer()
+	hosts := []virtualHost{{hostname: "app.loc"}}
+
+	cl.recordClaims(ContainerInfo{ID: "aaa", Name: "first"}, hosts, "/api")
+	cl.releaseClaims("aaa")
+
+	if _, held := cl.claims[routeClaim{host: "app.loc", path: "/api"}]; held {
+		t.Fatal("route is still claimed after the holder was released")
+	}
+
+	cl.recordClaims(ContainerInfo{ID: "bbb", Name: "second"}, hosts, "/api")
+	if got := cl.claims[routeClaim{host: "app.loc", path: "/api"}].name; got != "second" {
+		t.Errorf("claim holder = %q, want second", got)
+	}
+}
+
+// Two containers claiming a bare host collide on the same key as two claiming
+// one path, so the existing single-host case is covered by the same mechanism.
+func TestRecordClaimsCoversBareHosts(t *testing.T) {
+	cl := testLayer()
+	hosts := []virtualHost{{hostname: "app.loc"}}
+
+	cl.recordClaims(ContainerInfo{ID: "aaa", Name: "first"}, hosts, "")
+	cl.recordClaims(ContainerInfo{ID: "bbb", Name: "second"}, hosts, "")
+
+	if got := cl.claims[routeClaim{host: "app.loc"}].name; got != "first" {
+		t.Errorf("claim holder = %q, want it to stay with first", got)
 	}
 }

--- a/examples/applications.yml
+++ b/examples/applications.yml
@@ -64,17 +64,47 @@ services:
     environment:
       - VIRTUAL_HOST=whoami-https.loc # Automatically available on both HTTP and HTTPS
 
-  # Example 7: API with Traefik CORS labels (if needed)
+  # Example 7: API with Traefik CORS labels
+  #
+  # A container carrying any traefik. label is handled by Traefik's Docker
+  # provider, so VIRTUAL_HOST is ignored for it. Once you add a middleware
+  # label you own the routing too: declare both routers and the service.
   whoami-cors:
     image: traefik/whoami:latest
-    environment:
-      - VIRTUAL_HOST=api.loc
     labels:
-      # Example CORS configuration using Traefik labels
+      - "traefik.enable=true"
+      # CORS middleware
       - "traefik.http.middlewares.api-cors.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.api-cors.headers.accesscontrolallowmethods=GET,OPTIONS,PUT,POST,DELETE,PATCH"
+      # HTTP router
+      - "traefik.http.routers.api-http.rule=Host(`api.loc`)"
+      - "traefik.http.routers.api-http.entrypoints=http"
       - "traefik.http.routers.api-http.middlewares=api-cors"
+      # HTTPS router
+      - "traefik.http.routers.api-https.rule=Host(`api.loc`)"
+      - "traefik.http.routers.api-https.entrypoints=https"
+      - "traefik.http.routers.api-https.tls=true"
       - "traefik.http.routers.api-https.middlewares=api-cors"
+      - "traefik.http.services.api.loadbalancer.server.port=80"
+
+  # Example 8: two containers sharing one domain, so a page and the API it
+  # calls are on the same origin: no CORS, no preflight, one certificate.
+  #
+  # onehost.loc/      -> whoami-frontend
+  # onehost.loc/api   -> whoami-backend
+  #
+  # Nothing is stripped, so the backend receives /api/... and has to serve that
+  # prefix itself.
+  whoami-frontend:
+    image: traefik/whoami:latest
+    environment:
+      - VIRTUAL_HOST=onehost.loc
+
+  whoami-backend:
+    image: traefik/whoami:latest
+    environment:
+      - VIRTUAL_HOST=onehost.loc
+      - VIRTUAL_PATH=/api
 
 networks:
   default:

--- a/pkg/config/traefik.go
+++ b/pkg/config/traefik.go
@@ -15,8 +15,15 @@ type HTTPConfig struct {
 
 // Router represents a Traefik router configuration
 type Router struct {
-	Rule        string           `yaml:"rule,omitempty"`
-	Service     string           `yaml:"service,omitempty"`
+	Rule    string `yaml:"rule,omitempty"`
+	Service string `yaml:"service,omitempty"`
+	// Priority orders this router against every other one on the same
+	// entrypoint. Left unset, Traefik ranks by rule length instead. Only
+	// path-mounted routers set it, so host-only routers keep the ordering they
+	// have always had. omitempty is therefore load-bearing rather than
+	// cosmetic: a zero would erase the field and silently restore rule-length
+	// ordering, which is why the value assigned is never zero.
+	Priority    int              `yaml:"priority,omitempty"`
 	EntryPoints []string         `yaml:"entryPoints,omitempty"`
 	Middlewares []string         `yaml:"middlewares,omitempty"`
 	TLS         *RouterTLSConfig `yaml:"tls,omitempty"`

--- a/test/test.sh
+++ b/test/test.sh
@@ -699,7 +699,9 @@ run_body_container() {
 # Redirects are followed: nginx answers /api with a 301 to /api/ when serving a
 # directory, and that redirect page looks the same from either container, so
 # without -L the assertion could not tell them apart. --resolve rather than a
-# Host header, so the redirect target resolves back through the proxy.
+# Host header, so the redirect target resolves back through the proxy, and both
+# ports are mapped because the backend does not know the request arrived over
+# TLS and sends its redirect to the http scheme.
 test_body() {
     local hostname=$1 path=$2 expected=$3 label=$4
     local max_attempts=10
@@ -709,7 +711,10 @@ test_body() {
     log "Testing ${label}..."
 
     while [ $attempt -le $max_attempts ]; do
-        body="$(curl -s -L --resolve "${hostname}:${HTTP_PORT}:127.0.0.1" "http://${hostname}${path}" 2>/dev/null || true)"
+        body="$(curl -s -L \
+            --resolve "${hostname}:${HTTP_PORT}:127.0.0.1" \
+            --resolve "${hostname}:443:127.0.0.1" \
+            "http://${hostname}${path}" 2>/dev/null || true)"
         if [ "$body" = "$expected" ]; then
             success "${label}"
             return 0
@@ -732,7 +737,10 @@ test_body_https() {
     log "Testing ${label}..."
 
     while [ $attempt -le $max_attempts ]; do
-        body="$(curl -s -k -L --resolve "${hostname}:443:127.0.0.1" "https://${hostname}${path}" 2>/dev/null || true)"
+        body="$(curl -s -k -L \
+            --resolve "${hostname}:443:127.0.0.1" \
+            --resolve "${hostname}:${HTTP_PORT}:127.0.0.1" \
+            "https://${hostname}${path}" 2>/dev/null || true)"
         if [ "$body" = "$expected" ]; then
             success "${label}"
             return 0
@@ -774,8 +782,8 @@ test_virtual_path_routing() {
 
     # HTTPS must route identically.
     total=$((total + 1))
-    test_body_https "$PATH_HOSTNAME" "/api" "$PATH_MOUNTED_BODY" \
-        "/api over HTTPS is served by the mounted container" && passed=$((passed + 1))
+    test_body_https "$PATH_HOSTNAME" "/api/" "$PATH_MOUNTED_BODY" \
+        "/api/ over HTTPS is served by the mounted container" && passed=$((passed + 1))
 
     total=$((total + 1))
     test_body_https "$PATH_HOSTNAME" "/" "$PATH_ROOT_BODY" \

--- a/test/test.sh
+++ b/test/test.sh
@@ -42,6 +42,10 @@ VIRTUAL_HOST_PORT_CONTAINER="test-virtual-host-port-app"
 MULTI_VIRTUAL_HOST_CONTAINER="test-multi-virtual-host-app"
 ORPHAN_CONTAINER="test-orphan-reconcile-app"
 ONEOFF_CONTAINER="test-oneoff-app"
+PATH_ROOT_CONTAINER="test-path-root-app"
+PATH_MOUNTED_CONTAINER="test-path-mounted-app"
+WILDCARD_CONTAINER="test-wildcard-app"
+WILDCARD_MOUNTED_CONTAINER="test-wildcard-mounted-app"
 
 # Hostname configurations for DNS testing
 TRAEFIK_HOSTNAME="app1.${TEST_DOMAIN}"
@@ -51,6 +55,16 @@ MULTI_VIRTUAL_HOST_HOSTNAME1="app4.${TEST_DOMAIN}"
 MULTI_VIRTUAL_HOST_HOSTNAME2="app5.${TEST_DOMAIN}"
 ORPHAN_HOSTNAME="app6.${TEST_DOMAIN}"
 ONEOFF_HOSTNAME="app7.${TEST_DOMAIN}"
+PATH_HOSTNAME="app8.${TEST_DOMAIN}"
+WILDCARD_HOSTNAME="app9.wild.${TEST_DOMAIN}"
+
+# Bodies that identify which container answered. A mounted path cannot be
+# checked by status code: when its route is missing the request falls through to
+# the container serving the hostname, which answers 200 from the wrong place.
+PATH_ROOT_BODY="body-from-root-container"
+PATH_MOUNTED_BODY="body-from-mounted-container"
+WILDCARD_BODY="body-from-wildcard-container"
+WILDCARD_MOUNTED_BODY="body-from-wildcard-mounted-container"
 
 # Logging function
 log() {
@@ -662,9 +676,153 @@ test_with_dns_config() {
     [ "$passed" -eq "$total" ]
 }
 
+# Serve a fixed body from an nginx container, at the root and under a path, so
+# a response identifies which container produced it. nginx:alpine is used
+# throughout because wait_for_container probes readiness by running curl inside
+# the container, which an image without a shell can never satisfy.
+run_body_container() {
+    local name=$1 body=$2
+    shift 2
+
+    docker run -d --name "$name" \
+        -e "BODY=$body" \
+        "$@" \
+        nginx:alpine sh -c 'mkdir -p /usr/share/nginx/html/api /usr/share/nginx/html/api-docs && \
+            printf "%s" "$BODY" > /usr/share/nginx/html/index.html && \
+            printf "%s" "$BODY" > /usr/share/nginx/html/api/index.html && \
+            printf "%s" "$BODY" > /usr/share/nginx/html/api-docs/index.html && \
+            exec nginx -g "daemon off;"'
+}
+
+# Fetch a URL through the proxy and compare the body against what is expected.
+test_body() {
+    local hostname=$1 path=$2 expected=$3 label=$4
+    local max_attempts=10
+    local attempt=1
+    local body=""
+
+    log "Testing ${label}..."
+
+    while [ $attempt -le $max_attempts ]; do
+        body="$(curl -s -H "Host: ${hostname}" "http://localhost:${HTTP_PORT}${path}" 2>/dev/null || true)"
+        if [ "$body" = "$expected" ]; then
+            success "${label}"
+            return 0
+        fi
+        wait_with_message "$SLEEP_CONFIG_RESTORE" "for routing to settle"
+        attempt=$((attempt + 1))
+    done
+
+    error "${label} (got '${body:-<empty>}', expected '${expected}')"
+    return 1
+}
+
+# The same over HTTPS, so the two schemes cannot diverge unnoticed.
+test_body_https() {
+    local hostname=$1 path=$2 expected=$3 label=$4
+    local max_attempts=10
+    local attempt=1
+    local body=""
+
+    log "Testing ${label}..."
+
+    while [ $attempt -le $max_attempts ]; do
+        body="$(curl -s -k --resolve "${hostname}:443:127.0.0.1" "https://${hostname}${path}" 2>/dev/null || true)"
+        if [ "$body" = "$expected" ]; then
+            success "${label}"
+            return 0
+        fi
+        wait_with_message "$SLEEP_CONFIG_RESTORE" "for routing to settle"
+        attempt=$((attempt + 1))
+    done
+
+    error "${label} (got '${body:-<empty>}', expected '${expected}')"
+    return 1
+}
+
+# VIRTUAL_PATH: a container mounted under a path of a hostname another container
+# serves. Every assertion compares bodies, because status codes cannot tell a
+# working path route from a request falling through to the host.
+test_virtual_path_routing() {
+    local passed=0 total=0
+
+    # The root of the shared hostname belongs to the container without a path.
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/" "$PATH_ROOT_BODY" \
+        "root of ${PATH_HOSTNAME} is served by the host container" && passed=$((passed + 1))
+
+    # The mounted path, and anything beneath it, belongs to the mounted one.
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/api" "$PATH_MOUNTED_BODY" \
+        "/api is served by the mounted container" && passed=$((passed + 1))
+
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/api/" "$PATH_MOUNTED_BODY" \
+        "/api/ is served by the mounted container" && passed=$((passed + 1))
+
+    # The regression this feature exists to avoid: PathPrefix alone is a raw
+    # string prefix in Traefik, so /api would also capture /api-docs. Both
+    # containers serve /api-docs, so only the body distinguishes them.
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/api-docs/" "$PATH_ROOT_BODY" \
+        "/api-docs is not captured by the /api mount" && passed=$((passed + 1))
+
+    # HTTPS must route identically.
+    total=$((total + 1))
+    test_body_https "$PATH_HOSTNAME" "/api" "$PATH_MOUNTED_BODY" \
+        "/api over HTTPS is served by the mounted container" && passed=$((passed + 1))
+
+    total=$((total + 1))
+    test_body_https "$PATH_HOSTNAME" "/" "$PATH_ROOT_BODY" \
+        "root over HTTPS is served by the host container" && passed=$((passed + 1))
+
+    log "VIRTUAL_PATH routing: ${passed}/${total} checks passed"
+    [ "$passed" -eq "$total" ]
+}
+
+# A mounted path must outrank a wildcard that also matches its hostname. Without
+# an explicit priority this depends on which generated rule happens to be the
+# longer string, which is not something to leave to chance.
+test_virtual_path_beats_wildcard() {
+    local passed=0 total=0
+
+    total=$((total + 1))
+    test_body "$WILDCARD_HOSTNAME" "/" "$WILDCARD_BODY" \
+        "root of ${WILDCARD_HOSTNAME} is served by the wildcard container" && passed=$((passed + 1))
+
+    total=$((total + 1))
+    test_body "$WILDCARD_HOSTNAME" "/api" "$WILDCARD_MOUNTED_BODY" \
+        "/api outranks the wildcard covering the same hostname" && passed=$((passed + 1))
+
+    log "VIRTUAL_PATH against a wildcard: ${passed}/${total} checks passed"
+    [ "$passed" -eq "$total" ]
+}
+
+# Stopping the mounted container removes its routes, so its paths fall through
+# to whatever serves the hostname. A deployed ingress behaves the same way, so
+# this is pinned as intended behaviour rather than left to be discovered.
+test_virtual_path_fallthrough() {
+    log "Stopping the mounted container to check the documented fall-through..."
+    docker rm -f "$PATH_MOUNTED_CONTAINER" >/dev/null 2>&1 || true
+    wait_with_message "$SLEEP_PROXY_CONFIG" "for the mounted route to be withdrawn"
+
+    local passed=0 total=0
+
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/api" "$PATH_ROOT_BODY" \
+        "/api falls through to the host container once the mounted one stops" && passed=$((passed + 1))
+
+    total=$((total + 1))
+    test_body "$PATH_HOSTNAME" "/" "$PATH_ROOT_BODY" \
+        "the host container is unaffected" && passed=$((passed + 1))
+
+    log "VIRTUAL_PATH fall-through: ${passed}/${total} checks passed"
+    [ "$passed" -eq "$total" ]
+}
+
 # Cleanup test containers
 cleanup() {
-    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" "$ORPHAN_CONTAINER" "$ONEOFF_CONTAINER" 2>/dev/null || true
+    docker rm -f "$TRAEFIK_CONTAINER" "$VIRTUAL_HOST_CONTAINER" "$VIRTUAL_HOST_PORT_CONTAINER" "$MULTI_VIRTUAL_HOST_CONTAINER" "$ORPHAN_CONTAINER" "$ONEOFF_CONTAINER" "$PATH_ROOT_CONTAINER" "$PATH_MOUNTED_CONTAINER" "$WILDCARD_CONTAINER" "$WILDCARD_MOUNTED_CONTAINER" 2>/dev/null || true
 }
 
 # Full stack cleanup and rebuild
@@ -716,11 +874,27 @@ main() {
         --env "VIRTUAL_HOST=app4.${TEST_DOMAIN},app5.${TEST_DOMAIN}" \
         --env "VIRTUAL_PORT=80" nginx:alpine
 
+    # Two containers sharing one hostname: the second is mounted under /api.
+    run_body_container "$PATH_ROOT_CONTAINER" "$PATH_ROOT_BODY" \
+        --env "VIRTUAL_HOST=${PATH_HOSTNAME}"
+    run_body_container "$PATH_MOUNTED_CONTAINER" "$PATH_MOUNTED_BODY" \
+        --env "VIRTUAL_HOST=${PATH_HOSTNAME}" --env "VIRTUAL_PATH=/api"
+
+    # A wildcard covering the same hostname, to prove the mount outranks it.
+    run_body_container "$WILDCARD_CONTAINER" "$WILDCARD_BODY" \
+        --env "VIRTUAL_HOST=*.wild.${TEST_DOMAIN}"
+    run_body_container "$WILDCARD_MOUNTED_CONTAINER" "$WILDCARD_MOUNTED_BODY" \
+        --env "VIRTUAL_HOST=${WILDCARD_HOSTNAME}" --env "VIRTUAL_PATH=/api"
+
     # Wait for containers
     wait_for_container "$TRAEFIK_CONTAINER"
     wait_for_container "$VIRTUAL_HOST_CONTAINER"
     wait_for_container "$VIRTUAL_HOST_PORT_CONTAINER"
     wait_for_container "$MULTI_VIRTUAL_HOST_CONTAINER"
+    wait_for_container "$PATH_ROOT_CONTAINER"
+    wait_for_container "$PATH_MOUNTED_CONTAINER"
+    wait_for_container "$WILDCARD_CONTAINER"
+    wait_for_container "$WILDCARD_MOUNTED_CONTAINER"
     wait_with_message "$SLEEP_PROXY_CONFIG" "for proxy configuration to propagate"
 
     # Run tests
@@ -761,6 +935,27 @@ main() {
     local oneoff_passed=0
     test_oneoff_container_ignored && oneoff_passed=1
     [ "$oneoff_passed" -eq 1 ] && passed=$((passed + 1))
+
+    # VIRTUAL_PATH routing (issue #113)
+    log "Testing VIRTUAL_PATH routing..."
+    total=$((total + 1))
+    local vpath_passed=0
+    test_virtual_path_routing && vpath_passed=1
+    [ "$vpath_passed" -eq 1 ] && passed=$((passed + 1))
+
+    log "Testing VIRTUAL_PATH against a wildcard host..."
+    total=$((total + 1))
+    local vpath_wildcard_passed=0
+    test_virtual_path_beats_wildcard && vpath_wildcard_passed=1
+    [ "$vpath_wildcard_passed" -eq 1 ] && passed=$((passed + 1))
+
+    # Runs last of the VIRTUAL_PATH suites: it removes the mounted container,
+    # so anything after it would see the hostname without its path.
+    log "Testing VIRTUAL_PATH fall-through when the mounted container stops..."
+    total=$((total + 1))
+    local vpath_fallthrough_passed=0
+    test_virtual_path_fallthrough && vpath_fallthrough_passed=1
+    [ "$vpath_fallthrough_passed" -eq 1 ] && passed=$((passed + 1))
 
     # DNS Tests (if dig available)
     if command -v dig >/dev/null 2>&1; then

--- a/test/test.sh
+++ b/test/test.sh
@@ -695,6 +695,11 @@ run_body_container() {
 }
 
 # Fetch a URL through the proxy and compare the body against what is expected.
+#
+# Redirects are followed: nginx answers /api with a 301 to /api/ when serving a
+# directory, and that redirect page looks the same from either container, so
+# without -L the assertion could not tell them apart. --resolve rather than a
+# Host header, so the redirect target resolves back through the proxy.
 test_body() {
     local hostname=$1 path=$2 expected=$3 label=$4
     local max_attempts=10
@@ -704,7 +709,7 @@ test_body() {
     log "Testing ${label}..."
 
     while [ $attempt -le $max_attempts ]; do
-        body="$(curl -s -H "Host: ${hostname}" "http://localhost:${HTTP_PORT}${path}" 2>/dev/null || true)"
+        body="$(curl -s -L --resolve "${hostname}:${HTTP_PORT}:127.0.0.1" "http://${hostname}${path}" 2>/dev/null || true)"
         if [ "$body" = "$expected" ]; then
             success "${label}"
             return 0
@@ -727,7 +732,7 @@ test_body_https() {
     log "Testing ${label}..."
 
     while [ $attempt -le $max_attempts ]; do
-        body="$(curl -s -k --resolve "${hostname}:443:127.0.0.1" "https://${hostname}${path}" 2>/dev/null || true)"
+        body="$(curl -s -k -L --resolve "${hostname}:443:127.0.0.1" "https://${hostname}${path}" 2>/dev/null || true)"
         if [ "$body" = "$expected" ]; then
             success "${label}"
             return 0


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #113. Implements the specification merged in #114.

## What it does

A container setting `VIRTUAL_PATH` alongside `VIRTUAL_HOST` is mounted under that path of that hostname, so two containers can share one domain:

```yaml
frontend:
  environment:
    - VIRTUAL_HOST=myapp.local
    - VIRTUAL_PORT=5173

api:
  environment:
    - VIRTUAL_HOST=myapp.local # the same domain
    - VIRTUAL_PATH=/api # mounted under it
    - VIRTUAL_PORT=3000
```

`myapp.local/` reaches the frontend, `myapp.local/api/...` reaches the API, and the page can call `/api/...` with no host in front of it. No CORS, no preflight, one certificate.

`VIRTUAL_PATH` is [nginx-proxy's variable](https://github.com/nginx-proxy/nginx-proxy/blob/main/docs/README.md) for this, which is why it was chosen over inventing syntax inside `VIRTUAL_HOST`: `VIRTUAL_HOST` parsing is untouched, each container keeps its own `VIRTUAL_PORT`, and the `~`-regex form cannot have a slash reinterpreted.

## Two routing decisions worth reviewing

**Matching is by segment.** Traefik's `PathPrefix` is a raw string prefix, so `PathPrefix(`/api`)` also matches `/api-docs`. An ingress `pathType: Prefix` splits on separators and does not. Since the point is that one relative call behaves the same locally and once deployed, the emitted rule is:

```
Host(`myapp.local`) && (PathPrefix(`/api/`) || Path(`/api`))
```

**Priority is set on mounted routers only.** Traefik ranks routers by rule length when priority is unset, in one table per entrypoint, across providers. Setting a priority on the host routers this layer already emits would re-rank them against routers built from users' own `traefik.*` labels, and would replace today's stable exact-versus-wildcard ordering with an undefined tie. So host routers are emitted byte-identically to before, and only mounted routers carry a value. That value is non-zero deliberately: with `omitempty` a zero would be dropped and silently restore inherited ordering, which a test pins.

## Three silent failures that now warn

None are caused by this feature; the first two are simply easier to hit with it.

- A container carrying **any** `traefik.` label is skipped whole, so its `VIRTUAL_HOST` never routes. This is intentional precedence, but a middleware label alone triggers it. It was debug-level, so invisible by default.
- `VIRTUAL_PATH` with no `VIRTUAL_HOST` exposes nothing at all.
- Two containers claiming the same host and path. Tracked across container events rather than only at startup, since the proxy is normally already running when a stack starts.

## Also fixed

Example 7 in `examples/applications.yml` could never have worked: its CORS middleware label made the layer skip the container, so `VIRTUAL_HOST=api.loc` produced no route and the routers it referenced did not exist. It now declares its own routers.

`AGENTS.md` said the repository has no unit tests and that `make test` is the verification step. There are five `_test.go` files, and `make test` runs only the integration suite.

## Tests

**Unit** (`cmd/dinghy-layer/main_test.go`): every accepted and rejected path form, the rule asserted whole, the emitted YAML asserted for both the presence and the absence of priority, and the ordering against host and wildcard rules. I mutation-checked the three that matter: replacing the matcher with a naive `PathPrefix` fails 5 assertions, dropping the priority fails 6, removing the path validation fails 8.

**Integration** (`test/test.sh`): two containers sharing a hostname with distinct bodies, since status codes cannot distinguish a working mount from a fall-through. Covers the root, the mount, a nested path, `/api-docs` not being captured, both schemes, a wildcard not outranking the mount, and the documented fall-through when the mounted container stops.

**Diagnostic**: `self-test` starts a mounted container and checks it over both schemes by body.

## Security note

The rule is assembled by string formatting, so a path containing a backtick could close the matcher and append arbitrary routing syntax. Validation rejects anything that is not a single plain path, and there is a test for exactly that input.


___

### **PR Type**
Enhancement, Tests, Documentation, Bug fix


___

### **Description**
- Add `VIRTUAL_PATH` shared-host path routing

- Validate paths and prioritize mounted routers

- Warn about ignored and duplicate routes

- Cover routing, diagnostics, docs, and examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Container["Container with VIRTUAL_HOST and VIRTUAL_PATH"]
  Layer["dinghy layer"]
  Router["Prioritized segment-aware path router"]
  Backend["Mounted container backend"]
  Container -- "declares host and path" --> Layer
  Layer -- "writes Traefik route" --> Router
  Router -- "forwards unchanged request path" --> Backend
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Generate validated prioritized virtual path routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-6f7909d862402f3a0dd82ff94d73a0a7d2ebbbea860b2fd0e2f399338450dc06">+191/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>traefik.go</strong><dd><code>Add router priority YAML configuration support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-b56d8373a40a06efa5fa1321c9ae30fd034d2ff010344639c16b128a686ae36c">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spark-http-proxy</strong><dd><code>Validate certificate domains and path self-test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-2277567487100c466f0d7d1f0afcd58e899233b4b967787b9013630de99a5cdc">+93/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>main_test.go</strong><dd><code>Test path parsing routing priorities and claims</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-fb3677cf7fb77ec04aa325af43fabb6aa0a6a0dca85b19c1982e4bcc8692c70a">+263/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test.sh</strong><dd><code>Exercise virtual path routing end to end</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-68dc634ad3d79412c7330c0a047395557852ea0c6ab031596194f56aa1444104">+196/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Document virtual paths and test suite guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+26/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Record virtual path routing release changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Document shared-domain `VIRTUAL_PATH` configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>applications.yml</strong><dd><code>Fix CORS example and demonstrate path routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/http-proxy/pull/115/files#diff-1d833765b69d2a7b8cbd823f20a70b92ed274b36119429059a6ed701114399cd">+34/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra